### PR TITLE
fix(cicd): add permissions to deploy-infrastructure workflow

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -29,12 +29,18 @@ env:
   CDK_DEFAULT_REGION: "us-east-1"
   GITHUB_REPO: "infiquetra-aws-infra"
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: 🚀 Deploy to AWS
     # Only deploy from main branch
     if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/reusable-aws-deployment.yml
+    permissions:
+      id-token: write
+      contents: write
     with:
       environment: ${{ inputs.environment || 'production' }}
       stack: ${{ inputs.stack || 'all' }}


### PR DESCRIPTION
## Summary

The first push to `main` after merging #3 triggered the new `deploy-infrastructure.yml` workflow, which immediately died with `startup_failure` (run [24920573693](https://github.com/infiquetra/infiquetra-aws-infra/actions/runs/24920573693)). Cause: the caller workflow was missing a `permissions:` block, so the reusable `reusable-aws-deployment.yml` call could not be granted the `id-token: write` and `contents: write` it needs.

This is the same class of bug that was fixed for `pull-request-validation.yml` in commit `ac4abd4`, but the deploy workflow was missed because it can only be exercised on push to main.

## Changes

- Added top-level `permissions: contents: read` baseline (least-privilege for `post-deployment`)
- Added job-level `permissions: { id-token: write, contents: write }` to the `deploy` job that calls the reusable workflow

## Test plan

- [ ] PR validation pipeline passes
- [ ] On merge, `deploy-infrastructure.yml` starts successfully (no startup_failure)
- [ ] OIDC authentication succeeds and CDK synth/deploy proceeds