### PR TITLE
fix(cicd): invoke cdk deploy through uv run

### DIFF
--- a/.github/workflows/reusable-aws-deployment.yml
+++ b/.github/workflows/reusable-aws-deployment.yml
@@ -101,7 +101,7 @@ jobs:
             APPROVAL_FLAG=""
           fi
 
-          if cdk deploy InfiquetraOrganizationStack $APPROVAL_FLAG; then
+          if uv run cdk deploy InfiquetraOrganizationStack $APPROVAL_FLAG; then
             echo "✅ **Organization Stack deployed successfully**" >> $GITHUB_STEP_SUMMARY
             echo "status=success" >> $GITHUB_OUTPUT
           else
@@ -127,7 +127,7 @@ jobs:
             APPROVAL_FLAG=""
           fi
 
-          if cdk deploy InfiquetraSSOStack $APPROVAL_FLAG; then
+          if uv run cdk deploy InfiquetraSSOStack $APPROVAL_FLAG; then
             echo "✅ **SSO Stack deployed successfully**" >> $GITHUB_STEP_SUMMARY
             echo "status=success" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary

After #4 fixed the startup_failure, the next deploy run ([24927158328](https://github.com/infiquetra/infiquetra-aws-infra/actions/runs/24927158328)) reached the actual deploy step and failed with:

```
ModuleNotFoundError: No module named 'aws_cdk'
python3 app.py: Subprocess exited with error 1
```

`cdk.json` declares `"app": "python3 app.py"`, which uses system Python rather than the uv venv. The synthesis workflow already worked around this with `uv run cdk synth`. The deploy steps were missing the same wrapping.

## Changes

- `reusable-aws-deployment.yml`:
  - `cdk deploy InfiquetraOrganizationStack ...` → `uv run cdk deploy ...`
  - `cdk deploy InfiquetraSSOStack ...` → `uv run cdk deploy ...`

## Test plan

- [ ] PR validation passes
- [ ] On merge, deploy job reaches the CDK steps and `aws_cdk` imports successfully
- [ ] Organization stack and SSO stack deploy (or no-op against the existing AWS state)