### PR TITLE
chore(cicd): disable push-to-main auto-deploy until SCP fix lands

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -1,8 +1,10 @@
 name: Deploy Infrastructure
 
 on:
-  push:
-    branches: [ main ]
+  # Auto-deploy on push to main is intentionally disabled while the
+  # OrganizationStack SCP issue is being resolved. Re-enable by adding:
+  #   push:
+  #     branches: [ main ]
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## Summary

The post-#5 deploy run [24927809223](https://github.com/infiquetra/infiquetra-aws-infra/actions/runs/24927809223) reached AWS and failed:

```
AWS::Organizations::Policy | BaseSecuritySCP CREATE_FAILED
"The provided policy document does not meet the requirements of the specified policy type."
```

`InfiquetraOrganizationStack` is now stuck in `ROLLBACK_COMPLETE` and must be manually deleted before another deploy can succeed. While that AWS-side cleanup and the SCP code fix are in flight, every push to main would re-trigger the same failure.

This PR disables the `push: branches: [main]` trigger on `deploy-infrastructure.yml`. The workflow remains available via `workflow_dispatch` for manual deploys.

## Re-enabling

Add this back under `on:` once the SCP issue is resolved:
```yaml
push:
  branches: [ main ]
```

## Test plan

- [ ] PR validation passes
- [ ] After merge, push to main does NOT trigger a Deploy Infrastructure run
- [ ] Deploy Infrastructure can still be triggered manually via Actions UI