### PR TITLE
fix(scp): remove Principal field from Service Control Policy statements

### DIFF
--- a/infiquetra_aws_infra/organization_stack.py
+++ b/infiquetra_aws_infra/organization_stack.py
@@ -127,14 +127,16 @@ class OrganizationStack(Stack):
     def create_service_control_policies(self) -> None:
         """Create Service Control Policies for governance and security."""
 
-        # Base security policy for all business units
+        # Base security policy for all business units.
+        # SCPs implicitly apply to every principal in the target accounts and
+        # MUST NOT include a Principal field — AWS Organizations rejects the
+        # policy document otherwise.
         base_security_policy = {
             "Version": "2012-10-17",
             "Statement": [
                 {
                     "Sid": "DenyRootUserActions",
                     "Effect": "Deny",
-                    "Principal": {"AWS": "*"},
                     "Action": "*",
                     "Resource": "*",
                     "Condition": {"StringEquals": {"aws:PrincipalType": "Root"}},
@@ -142,7 +144,6 @@ class OrganizationStack(Stack):
                 {
                     "Sid": "DenyDeleteLoggingResources",
                     "Effect": "Deny",
-                    "Principal": {"AWS": "*"},
                     "Action": [
                         "logs:DeleteLogGroup",
                         "logs:DeleteLogStream",
@@ -154,7 +155,6 @@ class OrganizationStack(Stack):
                 {
                     "Sid": "RequireMFAForSensitiveActions",
                     "Effect": "Deny",
-                    "Principal": {"AWS": "*"},
                     "Action": [
                         "iam:DeleteUser",
                         "iam:DeleteRole",
@@ -189,14 +189,14 @@ class OrganizationStack(Stack):
             ],
         )
 
-        # Cost control policy for development environments
+        # Cost control policy for development environments.
+        # As above, no Principal field is allowed in SCP statements.
         dev_cost_control_policy = {
             "Version": "2012-10-17",
             "Statement": [
                 {
                     "Sid": "DenyExpensiveInstanceTypes",
                     "Effect": "Deny",
-                    "Principal": {"AWS": "*"},
                     "Action": "ec2:RunInstances",
                     "Resource": "arn:aws:ec2:*:*:instance/*",
                     "Condition": {


### PR DESCRIPTION
## Summary

The post-#5 deploy run [24927809223](https://github.com/infiquetra/infiquetra-aws-infra/actions/runs/24927809223) reached AWS Organizations and was rejected:

```
AWS::Organizations::Policy | BaseSecuritySCP CREATE_FAILED
"The provided policy document does not meet the requirements of the specified policy type."
```

Root cause: AWS Service Control Policies forbid the `Principal` element. SCPs implicitly apply to every principal in the target accounts. Including `"Principal": {"AWS": "*"}` in any statement causes AWS Organizations to reject the document.

All four statements in `organization_stack.py` had this issue (3 in `BaseSecurityPolicy`, 1 in `NonProductionCostControl`).

## Changes

- Removed `Principal` from all four SCP statements
- Added comments above each policy explaining the rule so it doesn't recur

## Verification

Local synth + cfn-lint both pass. Verified the rendered `Content` JSON for both SCPs has zero `Principal` keys:

```
=== BaseSecuritySCP (BaseSecurityPolicy) ===
  Sid=DenyRootUserActions  has_Principal=False
  Sid=DenyDeleteLoggingResources  has_Principal=False
  Sid=RequireMFAForSensitiveActions  has_Principal=False

=== NonProdCostControlSCP (NonProductionCostControl) ===
  Sid=DenyExpensiveInstanceTypes  has_Principal=False
```

## Required follow-up before deploy

`InfiquetraOrganizationStack` is currently stuck in `ROLLBACK_COMPLETE` from the failed run. It must be manually deleted from CloudFormation before this fix can be deployed, since CFN cannot transition a stack out of `ROLLBACK_COMPLETE` via update — only via delete + re-create.

## Test plan

- [ ] PR validation passes
- [ ] After merge: hand-delete the stuck stack in CloudFormation
- [ ] Manual `workflow_dispatch` of Deploy Infrastructure → SCPs deploy without the AWS rejection