### PR TITLE
feat(naming): Add resource_name() builder for consistent AWS names

### DIFF
--- a/infiquetra_aws_infra/naming.py
+++ b/infiquetra_aws_infra/naming.py
@@ -27,7 +27,7 @@ def resource_name(service: str, env: str, name: str, max_len: int = 64) -> str:
     ]:
         if not component:
             raise ValueError(f"{component_name} component cannot be empty")
-        if not all(c.isalnum() or c == '-' for c in component):
+        if not all((c >= 'a' and c <= 'z') or (c >= '0' and c <= '9') or c == '-' for c in component):
             raise ValueError(
                 f"{component_name} component contains illegal characters "
                 f"(only a-z, 0-9, - allowed)"

--- a/infiquetra_aws_infra/naming.py
+++ b/infiquetra_aws_infra/naming.py
@@ -1,0 +1,62 @@
+def resource_name(service: str, env: str, name: str, max_len: int = 64) -> str:
+    """
+    Generate a standardized AWS resource name with format "{service}-{env}-{name}".
+
+    Args:
+        service: Service identifier (e.g., "s3", "lambda")
+        env: Environment identifier (e.g., "dev", "prod")
+        name: Resource name identifier
+        max_len: Maximum allowed length for the full name (default: 64)
+
+    Returns:
+        str: Formatted resource name in lowercase
+
+    Raises:
+        ValueError: If any component is empty or contains illegal characters
+    """
+    # Normalize components to lowercase
+    service_part = service.lower()
+    env_part = env.lower()
+    name_part = name.lower()
+
+    # Validate components
+    for component, component_name in [
+        (service_part, "service"),
+        (env_part, "env"),
+        (name_part, "name")
+    ]:
+        if not component:
+            raise ValueError(f"{component_name} component cannot be empty")
+        if not all(c.isalnum() or c == '-' for c in component):
+            raise ValueError(
+                f"{component_name} component contains illegal characters "
+                f"(only a-z, 0-9, - allowed)"
+            )
+
+    # Build the candidate name
+    candidate = f"{service_part}-{env_part}-{name_part}"
+
+    # If within max_len, return as-is
+    if len(candidate) <= max_len:
+        return candidate
+
+    # Calculate prefix length
+    prefix = f"{service_part}-{env_part}-"
+    prefix_len = len(prefix)
+
+    # Check if prefix alone exceeds max_len
+    if prefix_len >= max_len:
+        raise ValueError(f"Prefix '{prefix}' exceeds max_len {max_len}")
+
+    # Calculate remaining capacity for name part
+    remaining_capacity = max_len - prefix_len
+
+    # If no capacity left for name, raise error
+    if remaining_capacity <= 0:
+        raise ValueError(
+            f"No capacity left for name component after prefix '{prefix}'"
+        )
+
+    # Truncate name part to fit
+    truncated_name = name_part[:remaining_capacity]
+    return prefix + truncated_name

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,52 @@
+import pytest
+from infiquetra_aws_infra.naming import resource_name
+
+
+def test_resource_name_happy_path():
+    """Test happy path case."""
+    result = resource_name("s3", "dev", "user-data")
+    assert result == "s3-dev-user-data"
+
+
+def test_resource_name_truncates_name_component_to_max_len():
+    """Test that long names are truncated to fit max_len."""
+    result = resource_name("lambda", "prod", "a" * 100, max_len=30)
+    expected_prefix = "lambda-prod-"
+    assert result.startswith(expected_prefix)
+    assert len(result) == 30
+
+
+def test_resource_name_rejects_empty_component():
+    """Test that empty components raise ValueError."""
+    with pytest.raises(ValueError, match="name component cannot be empty"):
+        resource_name("s3", "dev", "")
+
+
+def test_resource_name_rejects_illegal_characters():
+    """Test that illegal characters raise ValueError."""
+    with pytest.raises(ValueError, match="name component contains illegal characters"):
+        resource_name("s3", "dev", "Bad Name!")
+
+
+def test_resource_name_normalizes_case_to_lowercase():
+    """Test that uppercase inputs are normalized to lowercase."""
+    result = resource_name("S3", "DEV", "USER-DATA")
+    assert result == "s3-dev-user-data"
+
+
+def test_resource_name_rejects_empty_service():
+    """Test that empty service component raises ValueError."""
+    with pytest.raises(ValueError, match="service component cannot be empty"):
+        resource_name("", "dev", "user-data")
+
+
+def test_resource_name_rejects_empty_env():
+    """Test that empty env component raises ValueError."""
+    with pytest.raises(ValueError, match="env component cannot be empty"):
+        resource_name("s3", "", "user-data")
+
+
+def test_resource_name_prefix_exceeds_max_len():
+    """Test that prefix exceeding max_len raises ValueError."""
+    with pytest.raises(ValueError, match="Prefix .* exceeds max_len"):
+        resource_name("very-long-service-name", "very-long-env-name", "short", max_len=10)


### PR DESCRIPTION
## Linked card

Closes #9

## What changed

- Added `infiquetra_aws_infra/naming.py` with the `resource_name()` function that generates standardized AWS resource names
- Added `tests/test_naming.py` with comprehensive test coverage for all requirements:
  - Happy path case
  - Length truncation behavior
  - Empty component rejection
  - Illegal character rejection
  - Case normalization to lowercase
  - Additional edge cases like prefix exceeding max_len

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
python -m pytest tests/test_naming.py -v
```

Output:
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/agent/workspace/infiquetra/infiquetra-aws-infra
configfile: pyproject.toml
collected 8 items

tests/test_naming.py ........                                            [100%]

============================== 8 passed in 0.02s ===============================
```

Also verified with ruff linting:
```bash
ruff check infiquetra_aws_infra/naming.py
# Output: All checks passed!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body - ✓ addressed in `infiquetra_aws_infra/naming.py` function implementation
- AC 2: All named tests pass the verification command - ✓ addressed in `tests/test_naming.py` with 8 test cases covering all requirements
- AC 3: No dependencies added unless absolutely required - ✓ addressed by only using standard library features and existing pytest configuration

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated
- Do NOT add third-party dependencies unless required by the task body: not violated
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

The implementation follows all requirements from the task:
1. Format: `"{service}-{env}-{name}"` lowercased
2. If length exceeds `max_len`, truncate the name component to fit, preserving `{service}-{env}-` prefix
3. Reject illegal chars (only `a-z 0-9 -` allowed in output) — raise `ValueError` on invalid input chars
4. Reject empty components — raise `ValueError`

Added extra test cases beyond the minimum requirements to ensure robust error handling.

### Coverage

- AC 1 (verbatim): ✓ addressed in infiquetra_aws_infra/naming.py
- AC 2 (verbatim): ✓ addressed in tests/test_naming.py
- AC 3 (verbatim): ✓ addressed by dependency check