### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,36 @@
+"""Tagging utilities for standardized resource tagging."""
+
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """Generate common AWS resource tags.
+
+    Args:
+        env: Environment name. Must be one of: dev, staging, prod.
+        team: Team name.
+        project: Project name.
+
+    Returns:
+        Dict with standardized tag keys: Environment, Team, Project, ManagedBy.
+
+    Raises:
+        ValueError: If env is not one of the allowed values.
+    """
+    # Normalize inputs by stripping whitespace
+    env_normalized = env.strip()
+    team_normalized = team.strip()
+    project_normalized = project.strip()
+
+    # Validate environment
+    allowed_envs = {"dev", "staging", "prod"}
+    if env_normalized not in allowed_envs:
+        raise ValueError(
+            f"Invalid env '{env_normalized}'. Must be one of: {allowed_envs}"
+        )
+
+    # Build and return the tag dictionary
+    return {
+        "Environment": env_normalized,
+        "Team": team_normalized,
+        "Project": project_normalized,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,36 @@
+"""Tests for tagging utilities."""
+
+import pytest
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+@pytest.mark.parametrize("env", ["dev", "staging", "prod"])
+def test_common_tags_valid_environments(env: str) -> None:
+    """Test that valid environments return correct tags."""
+    result = common_tags(env, "platform", "auth")
+    assert result["Environment"] == env
+    assert result["Team"] == "platform"
+    assert result["Project"] == "auth"
+    assert result["ManagedBy"] == "CDK"
+
+
+def test_common_tags_raises_for_invalid_env() -> None:
+    """Test that invalid environment raises ValueError."""
+    with pytest.raises(ValueError):
+        common_tags("test", "x", "y")
+
+
+def test_common_tags_normalizes_whitespace() -> None:
+    """Test that inputs are normalized by stripping whitespace."""
+    result = common_tags("dev  ", " platform ", "auth")
+    assert result["Environment"] == "dev"
+    assert result["Team"] == "platform"
+    assert result["Project"] == "auth"
+
+
+def test_common_tags_returns_all_required_keys() -> None:
+    """Test that result contains all required keys."""
+    result = common_tags("dev", "platform", "auth")
+    expected_keys = {"Environment", "Team", "Project", "ManagedBy"}
+    assert set(result.keys()) == expected_keys


### PR DESCRIPTION
## Linked card

Closes #10

## What changed

- Added  helper function in 
  - Returns dict with keys: Environment, Team, Project, ManagedBy
  - ManagedBy always set to "CDK"
  - Validates env against dev/staging/prod, raises ValueError on invalid input
  - Strips/normalizes whitespace on all inputs before validation
- Added  with comprehensive pytest coverage

## How verified

============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/agent/workspace/infiquetra/infiquetra-aws-infra
configfile: pyproject.toml
plugins: anyio-4.9.0, typeguard-2.13.3
collected 6 items

tests/test_tagging.py ......                                             [100%]

============================== 6 passed in 0.09s ===============================

Output:


Also ran All checks passed! — all checks passed.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body (see Notes)): ✓ addressed in  lines 6-35
- AC 2 (All named tests pass the verification command): ✓ addressed in  with 6 tests passing
- AC 3 (No dependencies added unless absolutely required): ✓ no new dependencies added

### Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only modified  and 
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated — only added new code, no refactoring

### Notes

None — implementation follows approved plan exactly.