### PR TITLE
feat(naming): Add resource_name() builder for consistent AWS names

### DIFF
--- a/infiquetra_aws_infra/naming.py
+++ b/infiquetra_aws_infra/naming.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Naming utilities for AWS resource naming conventions."""
+
+import re
+
+
+def resource_name(service: str, env: str, name: str, max_len: int = 64) -> str:
+    """
+    Build a consistent AWS resource name in the format
+    '{service}-{env}-{name}', lowercased.
+
+    Args:
+        service: Service identifier (e.g., 's3', 'lambda').
+        env: Environment identifier (e.g., 'dev', 'prod').
+        name: Resource-specific name (e.g., 'user-data').
+        max_len: Maximum total length of the returned name. Defaults to 64.
+
+    Returns:
+        Lowercase string '{service}-{env}-{name}', truncated at max_len by
+        shortening only the `name` component.
+
+    Raises:
+        ValueError: If any component is empty, contains characters outside
+            [a-z0-9-] after lowercasing, or if max_len leaves no room for
+            the `name` component after the '{service}-{env}-' prefix.
+    """
+    # Validate inputs
+    if not service or not env or not name:
+        raise ValueError("service, env, and name must be non-empty strings")
+
+    # Lowercase each component for validation and formatting
+    service_lower = service.lower()
+    env_lower = env.lower()
+    name_lower = name.lower()
+
+    # Validate characters (only a-z, 0-9, hyphen allowed)
+    allowed_pattern = re.compile(r"^[a-z0-9-]+$")
+    if not allowed_pattern.match(service_lower):
+        raise ValueError(f"service contains invalid characters: {service!r}")
+    if not allowed_pattern.match(env_lower):
+        raise ValueError(f"env contains invalid characters: {env!r}")
+    if not allowed_pattern.match(name_lower):
+        raise ValueError(f"name contains invalid characters: {name!r}")
+
+    # Build prefix 'service-env-' and check length constraints
+    prefix = f"{service_lower}-{env_lower}-"
+    prefix_len = len(prefix)
+
+    if prefix_len >= max_len:
+        raise ValueError(
+            f"max_len={max_len} is too small to fit prefix '{prefix}' "
+            f"(length {prefix_len})"
+        )
+
+    remaining = max_len - prefix_len
+    # remaining is guaranteed >=1 here
+    truncated_name = name_lower[:remaining]
+    return prefix + truncated_name

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Tests for the resource_name naming utility."""
+
+import pytest
+
+from infiquetra_aws_infra.naming import resource_name
+
+
+def test_resource_name_happy_path() -> None:
+    """Happy-path test: simple lowercase and hyphen formatting."""
+    result = resource_name("s3", "dev", "user-data")
+    assert result == "s3-dev-user-data"
+
+
+def test_resource_name_truncates_name_to_max_len() -> None:
+    """Length limit triggers truncation of only the name component."""
+    long_name = "a" * 100
+    result = resource_name("lambda", "prod", long_name, max_len=30)
+    # prefix = "lambda-prod-" (12 chars)
+    # remaining = 30 - 12 = 18 chars for name
+    assert result.startswith("lambda-prod-")
+    assert len(result) == 30
+    assert result == "lambda-prod-" + ("a" * 18)
+
+
+def test_resource_name_truncates_name_exact_fit() -> None:
+    """Exactly fits max_len."""
+    # full "s3-dev-mybucket" length = 15
+    result = resource_name("s3", "dev", "mybucket", max_len=15)
+    assert result == "s3-dev-mybucket"
+    assert len(result) == 15
+
+
+def test_resource_name_rejects_empty_component() -> None:
+    """Empty service, env, or name raises ValueError."""
+    with pytest.raises(ValueError, match="must be non-empty"):
+        resource_name("", "dev", "something")
+    with pytest.raises(ValueError, match="must be non-empty"):
+        resource_name("s3", "", "something")
+    with pytest.raises(ValueError, match="must be non-empty"):
+        resource_name("s3", "dev", "")
+
+
+def test_resource_name_rejects_illegal_characters() -> None:
+    """Invalid characters raise ValueError."""
+    # uppercase letters are ok (they get lowercased), but punctuation is not
+    with pytest.raises(ValueError, match="contains invalid characters"):
+        resource_name("s3", "dev", "Bad Name!")
+    with pytest.raises(ValueError, match="contains invalid characters"):
+        resource_name("s3", "dev", "bucket@example")
+    with pytest.raises(ValueError, match="contains invalid characters"):
+        resource_name("s3", "de_v", "bucket")  # underscore invalid
+    with pytest.raises(ValueError, match="contains invalid characters"):
+        resource_name("s3!", "dev", "bucket")
+
+
+def test_resource_name_normalizes_case() -> None:
+    """Uppercase input is lowercased."""
+    result = resource_name("S3", "DEV", "USER-DATA")
+    assert result == "s3-dev-user-data"
+    # uppercase letters are allowed in input because they become lowercase
+    result2 = resource_name("Lambda", "Prod", "MyFunction")
+    assert result2 == "lambda-prod-myfunction"
+
+
+def test_resource_name_rejects_max_len_with_no_room_for_name() -> None:
+    """max_len too small to fit prefix raises ValueError."""
+    # prefix "s3-dev-" = 7 chars, max_len=6 -> error
+    with pytest.raises(
+        ValueError,
+        match="max_len=6 is too small to fit prefix 's3-dev-'",
+    ):
+        resource_name("s3", "dev", "anything", max_len=6)
+
+    # exactly equal length also raises because we need at least one char for name
+    with pytest.raises(
+        ValueError,
+        match="max_len=7 is too small to fit prefix 's3-dev-'",
+    ):
+        resource_name("s3", "dev", "anything", max_len=7)
+
+
+def test_resource_name_edge_cases() -> None:
+    """Edge cases: single-character components, allowed characters."""
+    result = resource_name("a", "b", "c")
+    assert result == "a-b-c"
+
+    result = resource_name("service", "env", "123-numbers")
+    assert result == "service-env-123-numbers"
+
+    # hyphen allowed in all positions
+    result = resource_name("my-service", "dev-env", "resource-name")
+    assert result == "my-service-dev-env-resource-name"
+
+    # max_len truncates hyphenated name correctly
+    result = resource_name("svc", "env", "a-b-c-d", max_len=10)
+    # prefix = "svc-env-" (8 chars), remaining = 2 chars for name -> "a-"
+    assert result == "svc-env-a-"
+    assert len(result) == 10
+
+
+def test_resource_name_default_max_len() -> None:
+    """Default max_len=64 works."""
+    name = "x" * 50
+    result = resource_name("s", "e", name)
+    # prefix "s-e-" = 4 chars, total length = 4 + 50 = 54 <= 64
+    assert result == f"s-e-{name}"
+    assert len(result) == 54
+    # should not truncate


### PR DESCRIPTION
## Linked card

Closes #13

## What changed

- Added `infiquetra_aws_infra/naming.py` with `resource_name(service: str, env: str, name: str, max_len: int = 64) -> str` function
- Added `tests/test_naming.py` with pytest coverage matching the task requirements: happy path, truncation length, empty component validation, illegal character validation, case normalization, and max_len boundary where prefix exceeds limit
- Both files pass `ruff check` and `mypy --strict`

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
pytest
```

Output digest:
- Collected 9 items
- All 9 tests passed in 0.09s

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — function validates empty components, lowercases and validates characters against `[a-z0-9-]`, truncates only the `name` component when necessary, raises `ValueError` when `max_len` is too small, and uses the exact format `{service}-{env}-{name}`.
- AC 2: All named tests pass the verification command — `pytest` runs all nine tests successfully, covering happy path (`test_resource_name_happy_path`), length truncation (`test_resource_name_truncates_name_to_max_len`), empty component rejection (`test_resource_name_rejects_empty_component`), illegal characters (`test_resource_name_rejects_illegal_characters`), case normalization (`test_resource_name_normalizes_case`), and boundary (`test_resource_name_rejects_max_len_with_no_room_for_name`)
- AC 3: No dependencies added unless absolutely required — no changes to `pyproject.toml`, `requirements.txt`, or `requirements-dev.txt`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below — modified only `infiquetra_aws_infra/naming.py` and `tests/test_naming.py`
- Do NOT add third-party dependencies unless required by the task body — no new dependencies added
- Do NOT refactor unrelated code in the touched files — only added new files, no modifications to other files

## Notes

- Implementation follows the exact validation rules specified in the task: lowercases all components before validation, ensures each component matches regex `^[a-z0-9-]+$`, raises clear `ValueError` messages.
- The truncation behavior as described truncates only the `name` component; if `max_len` ≤ prefix length, raises `ValueError` rather than returning a dangling prefix.
- Edge‑case tests added for hyphenated components and default `max_len=64`.

### Coverage

- AC 1 (verbatim): ✓ addressed in `infiquetra_aws_infra/naming.py#resource_name()` and its test suite
- AC 2 (verbatim): ✓ addressed via `pytest tests/test_naming.py` passes all nine tests
- AC 3 (verbatim): ✓ no dependencies added; package structure unchanged