### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,34 @@
+"""Standardized resource tagging helpers for AWS CDK stacks."""
+
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """
+    Return a standardized tag dict for AWS resources.
+
+    Args:
+        env: Deployment environment. Must be one of "dev", "staging", "prod".
+        team: Team responsible for the resource.
+        project: Project name.
+
+    Returns:
+        Dict with keys: Environment, Team, Project, ManagedBy.
+
+    Raises:
+        ValueError: If env is not one of "dev", "staging", "prod".
+    """
+    env_norm = env.strip()
+    team_norm = team.strip()
+    project_norm = project.strip()
+
+    valid_envs = {"dev", "staging", "prod"}
+    if env_norm not in valid_envs:
+        raise ValueError(
+            f"Invalid env {env_norm!r}: must be one of {sorted(valid_envs)}"
+        )
+
+    return {
+        "Environment": env_norm,
+        "Team": team_norm,
+        "Project": project_norm,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,35 @@
+"""Tests for tagging helpers."""
+
+import pytest
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+@pytest.mark.parametrize("env", ["dev", "staging", "prod"])
+def test_common_tags_accepts_valid_environments(env: str) -> None:
+    """Valid environments produce a tag dict with correct values."""
+    tags = common_tags(env, "platform", "auth")
+    assert tags["Environment"] == env
+    assert tags["Team"] == "platform"
+    assert tags["Project"] == "auth"
+    assert tags["ManagedBy"] == "CDK"
+
+
+def test_common_tags_rejects_invalid_environment() -> None:
+    """Non-dev/staging/prod env raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid env"):
+        common_tags("test", "x", "y")
+
+
+def test_common_tags_strips_whitespace_from_inputs() -> None:
+    """Input strings are normalized via strip()."""
+    tags = common_tags("dev  ", " platform ", "auth")
+    assert tags["Environment"] == "dev"
+    assert tags["Team"] == "platform"
+    assert tags["Project"] == "auth"
+
+
+def test_common_tags_returns_all_required_keys() -> None:
+    """Returned dict has exactly Environment, Team, Project, ManagedBy."""
+    tags = common_tags("prod", "sre", "platform")
+    assert set(tags.keys()) == {"Environment", "Team", "Project", "ManagedBy"}


### PR DESCRIPTION
## Linked card

Closes #16

## What changed

- Added `infiquetra_aws_infra/tagging.py` with `common_tags(env, team, project) -> dict[str, str]`
  - Normalizes all three inputs via `.strip()`
  - Validates env against {dev, staging, prod}, raises `ValueError` on others
  - Returns keys: Environment, Team, Project, ManagedBy=CDK
- Added `tests/test_tagging.py` with 6 pytest cases covering valid envs, invalid env, whitespace normalization, and required keys

## How verified

```
cd ~/workspace/infiquetra/infiquetra-aws-infra
PYTHONPATH=. pytest tests/test_tagging.py -v
```
Result: 6 passed in 0.02s

`ruff check` on both files: all checks passed

## Acceptance criteria coverage

- AC 1 (implementation matches all behaviors): ✓ addressed in `infiquetra_aws_infra/tagging.py::common_tags`
- AC 2 (all named tests pass): ✓ addressed in `tests/test_tagging.py` — 6 tests, all passing
- AC 3 (no new dependencies): ✓ addressed — pure Python stdlib, existing pytest from dev deps

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `tagging.py` and `test_tagging.py` changed
- Do NOT add third-party dependencies: not violated — no new deps introduced
- Do NOT refactor unrelated code: not violated — no refactors outside scoped files

## Notes

- Python 3.13 required by pyproject.toml but not available on the build VM; tests run via `PYTHONPATH=. pytest` to avoid editable install
- ManagedBy is hard-coded to "CDK" per the issue spec

### Coverage

- AC 1 (verbatim): ✓ addressed in `infiquetra_aws_infra/tagging.py::common_tags` — strips inputs, validates env, returns required keys with ManagedBy=CDK
- AC 2 (verbatim): ✓ addressed in `tests/test_tagging.py` — 6 tests covering valid envs, ValueError for invalid env, whitespace normalization, required keys present
- AC 3 (verbatim): ✓ addressed — pure Python helper, pytest from existing dev dependencies