### PR TITLE
feat(constructs): Add SecureBucket CDK construct with encryption + versioning

### DIFF
--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -12,7 +12,7 @@ class SecureBucket(Construct):
         construct_id: str,
         *,
         bucket_name: str | None = None
-    ):
+    ) -> None:
         """
         Initialize a SecureBucket construct.
 
@@ -27,15 +27,14 @@ class SecureBucket(Construct):
         processed_bucket_name = None
         if bucket_name is not None:
             try:
-                # Try to import the naming helper
-                from infiquetra_aws_infra.naming import resource_name
-                processed_bucket_name = resource_name(bucket_name)
-            except ImportError:
+                # Try to import the naming module
+                import infiquetra_aws_infra.naming as naming_module
+                # Try to get the resource_name function
+                resource_name_func = naming_module.resource_name
+                processed_bucket_name = resource_name_func(bucket_name)
+            except (ImportError, AttributeError):
                 # If the naming module doesn't exist or resource_name is not available,
                 # use the bucket name verbatim
-                processed_bucket_name = bucket_name
-            except AttributeError:
-                # If resource_name doesn't exist in the naming module, use verbatim
                 processed_bucket_name = bucket_name
 
         # Create the underlying bucket with secure defaults

--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,0 +1,55 @@
+from aws_cdk import RemovalPolicy
+from aws_cdk.aws_s3 import BlockPublicAccess, Bucket, BucketEncryption
+from constructs import Construct
+
+
+class SecureBucket(Construct):
+    """A secure S3 bucket construct with sensible defaults."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        bucket_name: str | None = None
+    ):
+        """
+        Initialize a SecureBucket construct.
+
+        Args:
+            scope: The scope in which to define this construct
+            construct_id: The scoped construct ID
+            bucket_name: Optional bucket name, validated via naming helper if available
+        """
+        super().__init__(scope, construct_id)
+
+        # Process bucket name with optional naming helper
+        processed_bucket_name = None
+        if bucket_name is not None:
+            try:
+                # Try to import the naming helper
+                from infiquetra_aws_infra.naming import resource_name
+                processed_bucket_name = resource_name(bucket_name)
+            except ImportError:
+                # If the naming module doesn't exist or resource_name is not available,
+                # use the bucket name verbatim
+                processed_bucket_name = bucket_name
+            except AttributeError:
+                # If resource_name doesn't exist in the naming module, use verbatim
+                processed_bucket_name = bucket_name
+
+        # Create the underlying bucket with secure defaults
+        self._bucket = Bucket(
+            self,
+            "Bucket",
+            bucket_name=processed_bucket_name,
+            encryption=BucketEncryption.S3_MANAGED,
+            versioned=True,
+            block_public_access=BlockPublicAccess.BLOCK_ALL,
+            removal_policy=RemovalPolicy.RETAIN
+        )
+
+    @property
+    def bucket(self) -> Bucket:
+        """Returns the underlying S3 Bucket instance."""
+        return self._bucket

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -1,0 +1,192 @@
+import sys
+from unittest.mock import MagicMock
+
+from aws_cdk import App, Stack
+from aws_cdk import aws_s3 as s3
+from aws_cdk.assertions import Template
+
+from infiquetra_aws_infra.constructs.secure_bucket import SecureBucket
+
+
+def test_secure_bucket_defaults():
+    """Test that SecureBucket creates a bucket with the correct defaults."""
+    # GIVEN
+    app = App()
+    stack = Stack(app, "TestStack")
+
+    # WHEN
+    SecureBucket(stack, "SecureBucket")
+    template = Template.from_stack(stack)
+
+    # THEN
+    # Should have exactly one S3 bucket
+    template.resource_count_is("AWS::S3::Bucket", 1)
+
+    # Should have S3-managed encryption
+    template.has_resource_properties("AWS::S3::Bucket", {
+        "BucketEncryption": {
+            "ServerSideEncryptionConfiguration": [
+                {
+                    "ServerSideEncryptionByDefault": {
+                        "SSEAlgorithm": "AES256"
+                    }
+                }
+            ]
+        }
+    })
+
+    # Should have versioning enabled
+    template.has_resource_properties("AWS::S3::Bucket", {
+        "VersioningConfiguration": {
+            "Status": "Enabled"
+        }
+    })
+
+    # Should block all public access
+    template.has_resource_properties("AWS::S3::Bucket", {
+        "PublicAccessBlockConfiguration": {
+            "BlockPublicAcls": True,
+            "BlockPublicPolicy": True,
+            "IgnorePublicAcls": True,
+            "RestrictPublicBuckets": True
+        }
+    })
+
+    # Should have RETAIN deletion policy
+    resources = template.find_resources("AWS::S3::Bucket")
+    bucket_resource_keys = list(resources.keys())
+    assert len(bucket_resource_keys) == 1
+    bucket_resource = resources[bucket_resource_keys[0]]
+    assert bucket_resource.get("DeletionPolicy") == "Retain"
+    # UpdateReplacePolicy is typically also Retain when DeletionPolicy is Retain
+    assert bucket_resource.get("UpdateReplacePolicy") == "Retain"
+
+
+def test_secure_bucket_exposes_underlying_bucket():
+    """Test that SecureBucket exposes the underlying Bucket instance."""
+    # GIVEN
+    app = App()
+    stack = Stack(app, "TestStack")
+
+    # WHEN
+    secure_bucket = SecureBucket(stack, "SecureBucket")
+
+    # THEN
+    assert secure_bucket.bucket is not None
+    assert isinstance(secure_bucket.bucket, s3.Bucket)
+
+
+def test_secure_bucket_with_explicit_name():
+    """Test that SecureBucket handles explicit bucket names correctly."""
+    # GIVEN
+    app = App()
+    stack = Stack(app, "TestStack")
+
+    # WHEN
+    bucket_name = "my-test-bucket"
+    SecureBucket(stack, "SecureBucket", bucket_name=bucket_name)
+    template = Template.from_stack(stack)
+
+    # THEN
+    template.has_resource_properties("AWS::S3::Bucket", {
+        "BucketName": bucket_name
+    })
+
+
+def test_secure_bucket_with_naming_helper():
+    """Test that SecureBucket uses naming helper when available."""
+    # GIVEN
+    app = App()
+    stack = Stack(app, "TestStack")
+
+    # Mock the naming module and resource_name function
+    mock_naming_module = MagicMock()
+    mock_resource_name = MagicMock(return_value="processed-bucket-name")
+    mock_naming_module.resource_name = mock_resource_name
+
+    # Temporarily replace the naming module in sys.modules
+    original_module = sys.modules.get('infiquetra_aws_infra.naming')
+    sys.modules['infiquetra_aws_infra.naming'] = mock_naming_module
+
+    try:
+        # WHEN
+        bucket_name = "original-bucket-name"
+        SecureBucket(stack, "SecureBucket", bucket_name=bucket_name)
+        template = Template.from_stack(stack)
+
+        # THEN
+        # Verify the resource_name function was called with the original bucket name
+        mock_resource_name.assert_called_once_with(bucket_name)
+
+        # Verify the processed name is used in the bucket properties
+        template.has_resource_properties("AWS::S3::Bucket", {
+            "BucketName": "processed-bucket-name"
+        })
+    finally:
+        # Restore original module
+        if original_module is not None:
+            sys.modules['infiquetra_aws_infra.naming'] = original_module
+        else:
+            sys.modules.pop('infiquetra_aws_infra.naming', None)
+
+
+def test_secure_bucket_without_naming_module():
+    """Test that SecureBucket falls back to verbatim name when naming module is missing."""
+    # GIVEN
+    app = App()
+    stack = Stack(app, "TestStack")
+
+    # Save original module if it exists
+    original_module = sys.modules.get('infiquetra_aws_infra.naming')
+
+    # Remove the naming module if it exists
+    if 'infiquetra_aws_infra.naming' in sys.modules:
+        del sys.modules['infiquetra_aws_infra.naming']
+
+    try:
+        # WHEN
+        bucket_name = "fallback-bucket-name"
+        SecureBucket(stack, "SecureBucket", bucket_name=bucket_name)
+        template = Template.from_stack(stack)
+
+        # THEN
+        template.has_resource_properties("AWS::S3::Bucket", {
+            "BucketName": bucket_name
+        })
+    finally:
+        # Restore original module
+        if original_module is not None:
+            sys.modules['infiquetra_aws_infra.naming'] = original_module
+
+
+def test_secure_bucket_without_resource_name_attribute():
+    """Test that SecureBucket falls back to verbatim name when resource_name is missing."""
+    # GIVEN
+    app = App()
+    stack = Stack(app, "TestStack")
+
+    # Mock the naming module without resource_name function
+    mock_naming_module = MagicMock()
+    if hasattr(mock_naming_module, 'resource_name'):
+        delattr(mock_naming_module, 'resource_name')
+
+    # Temporarily replace the naming module in sys.modules
+    original_module = sys.modules.get('infiquetra_aws_infra.naming')
+    sys.modules['infiquetra_aws_infra.naming'] = mock_naming_module
+
+    try:
+        # WHEN
+        bucket_name = "fallback-bucket-name"
+        SecureBucket(stack, "SecureBucket", bucket_name=bucket_name)
+        template = Template.from_stack(stack)
+
+        # THEN
+        template.has_resource_properties("AWS::S3::Bucket", {
+            "BucketName": bucket_name
+        })
+    finally:
+        # Restore original module
+        if original_module is not None:
+            sys.modules['infiquetra_aws_infra.naming'] = original_module
+        else:
+            sys.modules.pop('infiquetra_aws_infra.naming', None)

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -61,6 +61,10 @@ def test_secure_bucket_defaults():
     # UpdateReplacePolicy is typically also Retain when DeletionPolicy is Retain
     assert bucket_resource.get("UpdateReplacePolicy") == "Retain"
 
+    # Should not have BucketName specified (let CDK auto-generate)
+    bucket_props = bucket_resource.get("Properties", {})
+    assert "BucketName" not in bucket_props
+
 
 def test_secure_bucket_exposes_underlying_bucket():
     """Test that SecureBucket exposes the underlying Bucket instance."""


### PR DESCRIPTION
## Linked card

Closes #15

## What changed

- Added `SecureBucket` CDK construct in `infiquetra_aws_infra/constructs/secure_bucket.py` that wraps `aws_cdk.aws_s3.Bucket` with secure defaults:
  - S3-managed encryption (`encryption=BucketEncryption.S3_MANAGED`)
  - Versioning enabled (`versioned=True`)
  - Block all public access (`block_public_access=BlockPublicAccess.BLOCK_ALL`)
  - Retain removal policy (`removal_policy=RemovalPolicy.RETAIN`)
- Exposed the underlying `Bucket` via a `.bucket` property
- Implemented optional `bucket_name` parameter with naming helper support:
  - When `infiquetra_aws_infra.naming.resource_name` is available, use it to process the bucket name
  - When the naming helper is not available, fall back to using the bucket name verbatim
- Added comprehensive test suite in `tests/test_secure_bucket.py` with tests for:
  - Default secure settings verification using CDK assertions
  - Underlying bucket exposure via `.bucket` property
  - Explicit bucket name handling
  - Naming helper integration and fallback behavior

## How verified

```bash
$ cd ~/workspace/infiquetra/infiquetra-aws-infra
$ uv run pytest tests/test_secure_bucket.py
============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/agent/workspace/infiquetra/infiquetra-aws-infra
configfile: pyproject.toml
plugins: anyio-4.9.0, typeguard-2.13.3
collected 6 items

tests/test_secure_bucket.py ......                                       [100%]

============================== 6 passed in 19.46s ==============================
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes)
  - Addressed in `infiquetra_aws_infra/constructs/secure_bucket.py` and verified by tests in `tests/test_secure_bucket.py`
- AC 2: All named tests pass the verification command
  - Verified by running `uv run pytest tests/test_secure_bucket.py` which passes all 6 tests
- AC 3: No dependencies added unless absolutely required
  - Only used existing dependencies from `pyproject.toml`: `aws-cdk-lib`, `constructs`, and existing test dependency `pytest`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only modified the expected files
- Do NOT add third-party dependencies unless required by the task body: not violated - no new dependencies added
- Do NOT refactor unrelated code in the touched files: not violated - only added new files

## Notes

- The implementation follows the exact requirements from the task body
- Comprehensive test coverage ensures the construct behaves correctly in all scenarios
- The naming helper integration is implemented with proper fallback handling as specified

### Coverage

- AC 1 (verbatim): ✓ addressed in infiquetra_aws_infra/constructs/secure_bucket.py AND tests/test_secure_bucket.py
- AC 2 (verbatim): ✓ addressed in tests/test_secure_bucket.py with pytest verification
- AC 3 (verbatim): ✓ addressed by using only existing dependencies, verified by git diff showing no changes to pyproject.toml