### PR TITLE
feat(constructs): Add SecureBucket CDK construct with encryption + versioning

### DIFF
--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,0 +1,48 @@
+from aws_cdk import RemovalPolicy
+from aws_cdk import aws_s3 as s3
+from constructs import Construct
+
+
+class SecureBucket(Construct):
+    """
+    A secure S3 bucket construct with sensible defaults.
+    """
+
+    def __init__(
+        self, scope: Construct, construct_id: str, *, bucket_name: str | None = None
+    ) -> None:
+        super().__init__(scope, construct_id)
+
+        resolved_name = bucket_name
+        if bucket_name is not None:
+            try:
+                import infiquetra_aws_infra.naming as naming
+
+                if hasattr(naming, "resource_name"):
+                    helper = naming.resource_name
+                    if callable(helper):
+                        resolved_name = helper(bucket_name)
+                        if not isinstance(resolved_name, str):
+                            msg = (
+                                f"resource_name returned non-string: "
+                                f"{type(resolved_name)}"
+                            )
+                            raise TypeError(msg)
+            except ImportError:
+                # Helper module not available, fallback to verbatim
+                pass
+
+        self._bucket = s3.Bucket(
+            self,
+            "Bucket",
+            bucket_name=resolved_name,
+            encryption=s3.BucketEncryption.S3_MANAGED,
+            versioned=True,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+
+    @property
+    def bucket(self) -> s3.Bucket:
+        """Returns the underlying S3 bucket resource."""
+        return self._bucket

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -1,0 +1,96 @@
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from aws_cdk import App, Stack
+from aws_cdk import aws_s3 as s3
+from aws_cdk.assertions import Template
+
+from infiquetra_aws_infra.constructs.secure_bucket import SecureBucket
+
+
+class TestSecureBucket:
+    @pytest.fixture
+    def app(self) -> App:
+        return App()
+
+    @pytest.fixture
+    def stack(self, app: App) -> Stack:
+        return Stack(app, "TestStack")
+
+    def test_secure_bucket_sets_secure_defaults(self, stack: Stack) -> None:
+        SecureBucket(stack, "SecureBucket")
+        template = Template.from_stack(stack)
+
+        template.has_resource_properties(
+            "AWS::S3::Bucket",
+            {
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": [
+                        {"ServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}
+                    ]
+                },
+                "VersioningConfiguration": {"Status": "Enabled"},
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": True,
+                    "BlockPublicPolicy": True,
+                    "IgnorePublicAcls": True,
+                    "RestrictPublicBuckets": True,
+                },
+            },
+        )
+
+    def test_secure_bucket_sets_retain_policies(self, stack: Stack) -> None:
+        SecureBucket(stack, "SecureBucket")
+        template = Template.from_stack(stack)
+
+        template.has_resource(
+            "AWS::S3::Bucket",
+            {
+                "DeletionPolicy": "Retain",
+                "UpdateReplacePolicy": "Retain",
+            },
+        )
+
+    def test_secure_bucket_uses_bucket_name_verbatim_without_naming_helper(
+        self, stack: Stack
+    ) -> None:
+        # Ensure naming helper is not in sys.modules for this test
+        if "infiquetra_aws_infra.naming" in sys.modules:
+            del sys.modules["infiquetra_aws_infra.naming"]
+
+        bucket_name = "verbatim-bucket-name"
+        SecureBucket(stack, "SecureBucket", bucket_name=bucket_name)
+        template = Template.from_stack(stack)
+
+        template.has_resource_properties(
+            "AWS::S3::Bucket",
+            {"BucketName": bucket_name},
+        )
+
+    def test_secure_bucket_uses_naming_resource_name_when_available(
+        self, stack: Stack
+    ) -> None:
+        # Mock the naming module
+        mock_naming = MagicMock()
+        mock_naming.resource_name = MagicMock(return_value="transformed-bucket-name")
+        sys.modules["infiquetra_aws_infra.naming"] = mock_naming
+
+        try:
+            bucket_name = "original-bucket-name"
+            SecureBucket(stack, "SecureBucket", bucket_name=bucket_name)
+            template = Template.from_stack(stack)
+
+            template.has_resource_properties(
+                "AWS::S3::Bucket",
+                {"BucketName": "transformed-bucket-name"},
+            )
+            mock_naming.resource_name.assert_called_once_with(bucket_name)
+        finally:
+            if "infiquetra_aws_infra.naming" in sys.modules:
+                del sys.modules["infiquetra_aws_infra.naming"]
+
+    def test_secure_bucket_exposes_wrapped_bucket(self, stack: Stack) -> None:
+        sb = SecureBucket(stack, "SecureBucket")
+        assert isinstance(sb.bucket, s3.Bucket)
+        assert sb.bucket.node.id == "Bucket"


### PR DESCRIPTION
## Linked card

Closes #18

## What changed

- Added `SecureBucket` construct in `infiquetra_aws_infra/constructs/secure_bucket.py`.
- Implemented secure defaults: S3-managed encryption, versioning, block all public access, and retain removal policy.
- Added support for optional naming helper `infiquetra_aws_infra.naming.resource_name`.
- Exposed the underlying bucket resource via a read-only `.bucket` property.
- Added comprehensive unit tests in `tests/test_secure_bucket.py`.

## How verified

```bash
source .venv/bin/activate
pytest tests/test_secure_bucket.py
```

Output digest:
```
tests/test_secure_bucket.py ..... [100%]
5 passed in 30.93s
```

## Acceptance criteria coverage

- AC 1: Implementation follows all described behaviors including defaults and naming helper logic.
- AC 2: Tests pass verification command.
- AC 3: No new dependencies added.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated.
- Do NOT add third-party dependencies unless required by the task body: not violated.
- Do NOT refactor unrelated code in the touched files: not violated.

## Notes

- Created `infiquetra_aws_infra/constructs/` subdirectory.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in infiquetra_aws_infra/constructs/secure_bucket.py
- All named tests pass the verification command: ✓ addressed in tests/test_secure_bucket.py
- No dependencies added unless absolutely required: ✓ confirmed in pyproject.toml
