### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,34 @@
+"""Standardized resource tagging helpers for AWS CDK stacks."""
+
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """
+    Return a standardized tag dict for AWS resources.
+
+    Args:
+        env: Deployment environment. Must be one of "dev", "staging", "prod".
+        team: Team responsible for the resource.
+        project: Project name.
+
+    Returns:
+        Dict with keys: Environment, Team, Project, ManagedBy.
+
+    Raises:
+        ValueError: If env is not one of "dev", "staging", "prod".
+    """
+    env_norm = env.strip()
+    team_norm = team.strip()
+    project_norm = project.strip()
+
+    valid_envs = {"dev", "staging", "prod"}
+    if env_norm not in valid_envs:
+        raise ValueError(
+            f"Invalid env {env_norm!r}: must be one of {sorted(valid_envs)}"
+        )
+
+    return {
+        "Environment": env_norm,
+        "Team": team_norm,
+        "Project": project_norm,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,35 @@
+"""Tests for tagging helpers."""
+
+import pytest
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+@pytest.mark.parametrize("env", ["dev", "staging", "prod"])
+def test_common_tags_accepts_valid_environments(env: str) -> None:
+    """Valid environments produce a tag dict with correct values."""
+    tags = common_tags(env, "platform", "auth")
+    assert tags["Environment"] == env
+    assert tags["Team"] == "platform"
+    assert tags["Project"] == "auth"
+    assert tags["ManagedBy"] == "CDK"
+
+
+def test_common_tags_rejects_invalid_environment() -> None:
+    """Non-dev/staging/prod env raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid env"):
+        common_tags("test", "x", "y")
+
+
+def test_common_tags_strips_whitespace_from_inputs() -> None:
+    """Input strings are normalized via strip()."""
+    tags = common_tags("dev  ", " platform ", "auth")
+    assert tags["Environment"] == "dev"
+    assert tags["Team"] == "platform"
+    assert tags["Project"] == "auth"
+
+
+def test_common_tags_returns_all_required_keys() -> None:
+    """Returned dict has exactly Environment, Team, Project, ManagedBy."""
+    tags = common_tags("prod", "sre", "platform")
+    assert set(tags.keys()) == {"Environment", "Team", "Project", "ManagedBy"}


### PR DESCRIPTION
## Linked card

Closes #16

## What changed

- Created `infiquetra_aws_infra/tagging.py` with `common_tags(env: str, team: str, project: str) -> dict[str, str]`
  - Normalizes all inputs via `strip()`
  - Validates `env` against `{"dev", "staging", "prod"}`, raises `ValueError` on others
  - Returns dict with keys `Environment`, `Team`, `Project`, `ManagedBy` (hard-coded to `"CDK"`)
- Created `tests/test_tagging.py` with 4 test functions (6 parametrized cases)

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
PYTHONPATH=. pytest tests/test_tagging.py -v
# Output: 6 passed in 0.02s
ruff check infiquetra_aws_infra/tagging.py tests/test_tagging.py
# Output: All checks passed!
mypy infiquetra_aws_infra/tagging.py
# Output: Success: no issues found in 1 source file
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): ✓ `common_tags()` in `infiquetra_aws_infra/tagging.py` strips inputs, validates env against {dev, staging, prod}, raises ValueError on invalid env, returns dict with Environment/Team/Project/ManagedBy (ManagedBy="CDK")
- AC 2 (All named tests pass verification command): ✓ `tests/test_tagging.py` has `test_common_tags_accepts_valid_environments` (parametrized dev/staging/prod), `test_common_tags_rejects_invalid_environment`, `test_common_tags_strips_whitespace_from_inputs`, `test_common_tags_returns_all_required_keys` — all pass
- AC 3 (No dependencies added): ✓ Only stdlib used in implementation; pytest already in pyproject.toml dev dependencies

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `tagging.py` and `test_tagging.py` changed
- Do NOT add third-party dependencies: not violated — no new deps
- Do NOT refactor unrelated code: not violated — no unrelated changes

## Notes

- Tests require `PYTHONPATH=.` because the package isn't installed in the system Python (project requires Python >=3.13, VM has 3.12). This is a test runner environment issue, not a code issue.
- `mypy` on `tests/test_tagging.py` reports pytest import-not-found — pre-existing due to missing stubs in the system environment, not a new error.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `infiquetra_aws_infra/tagging.py` / `common_tags()`
- All named tests pass the verification command: ✓ addressed in `tests/test_tagging.py` / 4 test functions
- No dependencies added unless absolutely required: ✓ confirmed — no dependency changes in diff