### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,34 @@
+"""Common tagging utilities for AWS resource tagging."""
+
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """Return standardized tags for AWS resources.
+
+    Args:
+        env: Environment name (must be 'dev', 'staging', or 'prod').
+        team: Team name responsible for the resource.
+        project: Project identifier.
+
+    Returns:
+        Dict with keys: Environment, Team, Project, ManagedBy.
+
+    Raises:
+        ValueError: If env is not one of the allowed values.
+    """
+    normalized_env = env.strip()
+    normalized_team = team.strip()
+    normalized_project = project.strip()
+
+    valid_envs = {"dev", "staging", "prod"}
+    if normalized_env not in valid_envs:
+        raise ValueError(
+            f"Invalid environment '{normalized_env}'. "
+            f"Must be one of: {', '.join(sorted(valid_envs))}"
+        )
+
+    return {
+        "Environment": normalized_env,
+        "Team": normalized_team,
+        "Project": normalized_project,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,34 @@
+import pytest
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+@pytest.mark.parametrize("env", ["dev", "staging", "prod"])
+def test_common_tags_valid_envs(env: str) -> None:
+    """Test that valid environments return correct tags."""
+    result = common_tags(env, "platform", "auth")
+    assert result["Environment"] == env
+    assert result["Team"] == "platform"
+    assert result["Project"] == "auth"
+    assert result["ManagedBy"] == "CDK"
+
+
+def test_common_tags_invalid_env_raises_value_error() -> None:
+    """Test that invalid environment raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid environment 'test'"):
+        common_tags("test", "x", "y")
+
+
+def test_common_tags_normalizes_whitespace() -> None:
+    """Test that input strings are trimmed/stripped."""
+    result = common_tags("dev  ", " platform ", "auth")
+    assert result["Environment"] == "dev"
+    assert result["Team"] == "platform"
+    assert result["Project"] == "auth"
+
+
+def test_common_tags_returns_all_required_keys() -> None:
+    """Test that returned dict has exactly the required keys."""
+    result = common_tags("dev", "team1", "proj1")
+    expected_keys = {"Environment", "Team", "Project", "ManagedBy"}
+    assert set(result.keys()) == expected_keys


### PR DESCRIPTION
## Linked card

Closes #20

## What changed

- Created `infiquetra_aws_infra/tagging.py` with `common_tags(env, team, project)` function that returns standardized AWS resource tags
- Tags include: Environment, Team, Project, and ManagedBy (always "CDK")
- Validates environment against allowed values (dev, staging, prod) and raises ValueError on invalid input
- Normalizes/strips whitespace from all input strings
- Created `tests/test_tagging.py` with pytest coverage for all test cases

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
pytest tests/test_tagging.py -v
```

Output:
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/agent/workspace/infiquetra/infiquetra-aws-infra
collected 6 items

tests/test_tagging.py ......                                             [100%]

============================== 6 passed in 0.03s ===============================
```

Also verified with ruff check: `All checks passed!`

## Acceptance criteria coverage

- AC 1: ✓ Implementation matches all behaviors described in the task body
  - `common_tags()` validates env against {"dev", "staging", "prod"} (tagging.py:21-24)
  - Raises ValueError for invalid environments (tagging.py:22-25)
  - Normalizes whitespace on inputs (tagging.py:16-18)
  - Returns dict with Environment, Team, Project, ManagedBy keys (tagging.py:27-32)
  - ManagedBy is always "CDK" (tagging.py:32)
  
- AC 2: ✓ All named tests pass the verification command
  - `test_common_tags_valid_envs` - parametrized test for dev/staging/prod (test_tagging.py:7-14)
  - `test_common_tags_invalid_env_raises_value_error` - ValueError test (test_tagging.py:17-20)
  - `test_common_tags_normalizes_whitespace` - whitespace normalization test (test_tagging.py:23-28)
  - `test_common_tags_returns_all_required_keys` - keys presence test (test_tagging.py:31-35)
  
- AC 3: ✓ No dependencies added unless absolutely required
  - Implementation uses only built-in Python (str.strip(), set, dict)
  - Tests use pytest which is already in pyproject.toml

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: ✓ Only created `tagging.py` and `test_tagging.py`
- Do NOT add third-party dependencies unless required by the task body: ✓ No new dependencies
- Do NOT refactor unrelated code in the touched files: ✓ No unrelated code touched

## Notes

- None. Implementation follows the approved plan exactly.

### Coverage

- AC 1 ("Implementation matches all behaviors described in the task body"): ✓ addressed in `infiquetra_aws_infra/tagging.py` lines 16-32 and `tests/test_tagging.py`
- AC 2 ("All named tests pass the verification command"): ✓ addressed in `tests/test_tagging.py` with 6 tests passing
- AC 3 ("No dependencies added unless absolutely required"): ✓ addressed - implementation uses only built-in Python
