### PR TITLE
feat(constructs): Add SecureBucket CDK construct with encryption + versioning

### DIFF
--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+from typing import Any
+
+import aws_cdk as cdk
+from aws_cdk import aws_s3 as s3
+from constructs import Construct
+
+
+class SecureBucket(Construct):
+    """
+    Secure S3 Bucket construct with encryption and versioning enabled.
+
+    Wraps aws_cdk.aws_s3.Bucket with safe defaults:
+    - S3-managed encryption (AES256)
+    - Versioning enabled
+    - All block public access flags enabled
+    - Retains bucket on stack deletion or replacement
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        bucket_name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        # Apply secure defaults to the underlying S3 bucket
+        self._bucket = s3.Bucket(
+            self,
+            "Bucket",
+            bucket_name=bucket_name,
+            encryption=s3.BucketEncryption.S3_MANAGED,
+            versioned=True,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            removal_policy=cdk.RemovalPolicy.RETAIN,
+        )
+
+    @property
+    def bucket(self) -> s3.Bucket:
+        """Return the underlying S3 Bucket instance."""
+        return self._bucket

--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from typing import Any
-
 import aws_cdk as cdk
 from aws_cdk import aws_s3 as s3
 from constructs import Construct
@@ -24,9 +22,8 @@ class SecureBucket(Construct):
         construct_id: str,
         *,
         bucket_name: str | None = None,
-        **kwargs: Any,
     ) -> None:
-        super().__init__(scope, construct_id, **kwargs)
+        super().__init__(scope, construct_id)
 
         # Apply secure defaults to the underlying S3 bucket
         self._bucket = s3.Bucket(

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -87,9 +87,12 @@ class TestSecureBucket:
         test_stack = cdk.Stack(app, "TestExposeBucket")
         construct = SecureBucket(test_stack, "TestExposeBucketConstruct")
 
-        # Verify .bucket returns the underlying S3 Bucket
-        assert construct.bucket is not None
-        assert isinstance(construct.bucket, s3.Bucket)
+        # Verify .bucket returns the same underlying S3 Bucket instance
+        underlying_bucket = construct.bucket
+        assert underlying_bucket is not None
+        assert isinstance(underlying_bucket, s3.Bucket)
+        # Identity check: should be the exact same instance stored internally
+        assert construct.bucket is underlying_bucket
 
     def test_secure_bucket_uses_explicit_bucket_name_verbatim(
         self, app: App

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Unit tests for SecureBucket construct.
+
+Tests encryption, versioning, block public access, and deletion policy.
+"""
+
+import aws_cdk as cdk
+import pytest
+from aws_cdk import App, Environment
+from aws_cdk.assertions import Template
+
+from infiquetra_aws_infra.constructs.secure_bucket import SecureBucket, s3
+
+
+class TestSecureBucket:
+    """Test cases for SecureBucket construct."""
+
+    @pytest.fixture
+    def app(self) -> App:
+        """Create CDK App for testing."""
+        return App()
+
+    @pytest.fixture
+    def stack(self, app: App) -> cdk.Stack:
+        """Create a test stack with SecureBucket."""
+        return cdk.Stack(
+            app,
+            "TestSecureBucketStack",
+            env=Environment(account="123456789012", region="us-east-1"),
+        )
+
+    @pytest.fixture
+    def template(self, stack: cdk.Stack) -> Template:
+        """Create CloudFormation template for testing."""
+        SecureBucket(stack, "TestSecureBucket", bucket_name=None)
+        return Template.from_stack(stack)
+
+    def test_secure_bucket_applies_secure_defaults(self, template: Template) -> None:
+        """Test that the bucket has secure defaults.
+
+        Verifies encryption, versioning, and block public access settings.
+        """
+        # Check encryption: S3-managed encryptionAES256)
+        template.has_resource_properties(
+            "AWS::S3::Bucket",
+            {
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": [
+                        {"ServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}
+                    ]
+                },
+                "VersioningConfiguration": {"Status": "Enabled"},
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": True,
+                    "BlockPublicPolicy": True,
+                    "IgnorePublicAcls": True,
+                    "RestrictPublicBuckets": True,
+                },
+            },
+        )
+
+    def test_secure_bucket_retains_bucket_on_delete_or_replace(
+        self, template: Template
+    ) -> None:
+        """Test that the bucket is retained on deletion or replacement."""
+        # Get the bucket resource
+        buckets = template.find_resources("AWS::S3::Bucket")
+        assert len(buckets) >= 1, "No S3 bucket found in template"
+
+        # Check DeletionPolicy and UpdateReplacePolicy
+        for _bucket_name, bucket_resource in buckets.items():
+            deletion_policy = bucket_resource.get("DeletionPolicy")
+            update_replace_policy = bucket_resource.get("UpdateReplacePolicy")
+
+            # Verify both policies are set to Retain
+            assert deletion_policy == "Retain", (
+                f"DeletionPolicy should be Retain, got {deletion_policy}"
+            )
+            assert update_replace_policy == "Retain", (
+                f"UpdateReplacePolicy should be Retain, got {update_replace_policy}"
+            )
+
+    def test_secure_bucket_exposes_underlying_bucket(self, app: App) -> None:
+        """Test that the .bucket property exposes the underlying Bucket instance."""
+        # Create stack and construct
+        test_stack = cdk.Stack(app, "TestExposeBucket")
+        construct = SecureBucket(test_stack, "TestExposeBucketConstruct")
+
+        # Verify .bucket returns the underlying S3 Bucket
+        assert construct.bucket is not None
+        assert isinstance(construct.bucket, s3.Bucket)
+
+    def test_secure_bucket_uses_explicit_bucket_name_verbatim(
+        self, app: App
+    ) -> None:
+        """Test that an explicit bucket name is passed through verbatim."""
+        test_stack = cdk.Stack(
+            app,
+            "TestExplicitBucketNameStack",
+            env=Environment(account="123456789012", region="us-east-1"),
+        )
+        explicit_name = "my-secure-bucket-12345"
+        SecureBucket(test_stack, "TestExplicitBucketName", bucket_name=explicit_name)
+
+        # Synthesize and verify bucket name in template
+        template = Template.from_stack(test_stack)
+        buckets = template.find_resources("AWS::S3::Bucket")
+        assert len(buckets) >= 1, "No S3 bucket found in template"
+
+        for _bucket_name, bucket_resource in buckets.items():
+            props = bucket_resource.get("Properties", {})
+            assert props.get("BucketName") == explicit_name, (
+                f"BucketName should be {explicit_name}, got {props.get('BucketName')}"
+            )


### PR DESCRIPTION
## Linked card

Closes #32

## What changed

- **infiquetra_aws_infra/constructs/secure_bucket.py**: Added new SecureBucket construct class wrapping aws_cdk.aws_s3.Bucket with secure defaults (AES256 encryption, versioning, block public access, retain policy). Exposes underlying bucket via .bucket property.

- **tests/test_secure_bucket.py**: Added four test functions using aws_cdk.assertions.Template:
  - test_secure_bucket_applies_secure_defaults: Verifies encryption, versioning, and block public access settings
  - test_secure_bucket_retains_bucket_on_delete_or_replace: Verifies DeletionPolicy and UpdateReplacePolicy are Retain
  - test_secure_bucket_exposes_underlying_bucket: Verifies .bucket property returns underlying Bucket instance
  - test_secure_bucket_uses_explicit_bucket_name_verbatim: Verifies bucket name is passed through verbatim

## How verified

cd ~/workspace/infiquetra/infiquetra-aws-infra
.venv/bin/python -m pytest tests/test_secure_bucket.py -q

Output: .... (4/4 tests pass)
All ruff check passes on modified files.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in infiquetra_aws_infra/constructs/secure_bucket.py - SecureBucket class implements exact constructor signature with all required defaults, .bucket property exposed
- AC 2 (All named tests pass the verification command): ✓ addressed in tests/test_secure_bucket.py - All 4 named tests pass pytest verification
- AC 3 (No dependencies added unless absolutely required): ✓ confirmed - pyproject.toml already declares aws-cdk-lib, constructs, pytest as dependencies; no new deps added

## Non-goals acknowledged

- Do NOT modify files beyond expected set: ✓ not violated - only modified infiquetra_aws_infra/constructs/secure_bucket.py and tests/test_secure_bucket.py
- Do NOT add third-party dependencies unless required: ✓ not violated - only existing dependencies used
- Do NOT refactor unrelated code in touched files: ✓ not violated - no changes to existing files outside task scope

## Notes

- No naming.resource_name helper found in repo (verified via gh api tree inspection: no naming module exists)
- Bucket name parameter passed through verbatim when provided, None when not specified
- Follows repo patterns: typed __init__ saving resources on self, @property methods for derived data