### PR TITLE
[BENCH t01 deepseek-v3.2-c] feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,30 @@
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """
+    Generate common tags for AWS resources.
+
+    Args:
+        env: The environment (dev, staging, prod).
+        team: The team responsible for the resource.
+        project: The project name.
+
+    Returns:
+        A dictionary of tags.
+
+    Raises:
+        ValueError: If the environment is not one of dev, staging, or prod.
+    """
+    normalized_env = env.strip()
+    normalized_team = team.strip()
+    normalized_project = project.strip()
+
+    valid_envs = {"dev", "staging", "prod"}
+    if normalized_env not in valid_envs:
+        msg = f"Invalid environment '{normalized_env}'. Must be one of {valid_envs}"
+        raise ValueError(msg)
+
+    return {
+        "Environment": normalized_env,
+        "Team": normalized_team,
+        "Project": normalized_project,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,28 @@
+import pytest  # type: ignore
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+def test_common_tags_returns_expected_values_for_valid_envs() -> None:
+    for env in ["dev", "staging", "prod"]:
+        tags = common_tags(env, "platform", "auth")
+        assert tags["Environment"] == env
+        assert tags["Team"] == "platform"
+        assert tags["Project"] == "auth"
+        assert tags["ManagedBy"] == "CDK"
+
+def test_common_tags_raises_value_error_for_invalid_env() -> None:
+    with pytest.raises(ValueError, match="Invalid environment 'test'"):
+        common_tags("test", "x", "y")
+
+def test_common_tags_strips_whitespace_from_inputs() -> None:
+    tags = common_tags("dev  ", " platform ", "auth")
+    assert tags["Environment"] == "dev"
+    assert tags["Team"] == "platform"
+    assert tags["Project"] == "auth"
+
+def test_common_tags_includes_all_required_keys() -> None:
+    tags = common_tags("prod", "infra", "networking")
+    expected_keys = {"Environment", "Team", "Project", "ManagedBy"}
+    assert set(tags.keys()) == expected_keys
+    assert tags["ManagedBy"] == "CDK"


### PR DESCRIPTION
## Linked card

Closes #34

## What changed

- Added `infiquetra_aws_infra/tagging.py` with `common_tags()` helper.
- Added `tests/test_tagging.py` with full coverage for `common_tags()`.
- Implemented environment validation (dev, staging, prod) and whitespace normalization.
- Ensured `ManagedBy: CDK` is always present.

## How verified

Ran `pytest` with the following output:
```
....                                                                     [100%]
4 passed in 0.01s
```

Verified linting with `ruff check` and typing with `mypy`.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body: ✓ addressed in `infiquetra_aws_infra/tagging.py`
- AC 2: All named tests pass the verification command: ✓ addressed in `tests/test_tagging.py`
- AC 3: No dependencies added unless absolutely required: ✓ no new dependencies added

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated
- Do NOT add third-party dependencies: not violated
- Do NOT refactor unrelated code: not violated

### Coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `infiquetra_aws_infra/tagging.py`
- AC 2: All named tests pass the verification command: ✓ addressed in `tests/test_tagging.py`
- AC 3: No dependencies added unless absolutely required: ✓ addressed (no changes to pyproject.toml)