### PR TITLE
feat(constructs): Add SecureBucket CDK construct with encryption + versioning

### DIFF
--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,5 +1,7 @@
 """SecureBucket CDK construct with secure defaults."""
 
+from typing import Any
+
 from aws_cdk import RemovalPolicy
 from aws_cdk.aws_s3 import BlockPublicAccess, Bucket, BucketEncryption
 from constructs import Construct
@@ -24,9 +26,9 @@ class SecureBucket(Construct):
     ) -> None:
         super().__init__(scope, construct_id)
 
-        # No naming helper exists in this repo; bucket_name
-        # is passed verbatim to the underlying Bucket.
-        bucket_kwargs: dict = {
+        # Verified: no resource_name/naming helper exists in this repo
+        # (git grep confirms). bucket_name is passed verbatim to Bucket.
+        bucket_kwargs: dict[str, Any] = {
             "encryption": BucketEncryption.S3_MANAGED,
             "versioned": True,
             "block_public_access": BlockPublicAccess.BLOCK_ALL,

--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,0 +1,43 @@
+"""SecureBucket CDK construct with secure defaults."""
+
+from aws_cdk import RemovalPolicy
+from aws_cdk.aws_s3 import BlockPublicAccess, Bucket, BucketEncryption
+from constructs import Construct
+
+
+class SecureBucket(Construct):
+    """S3 bucket wrapper with encryption, versioning, and public-access
+    blocking.
+
+    Encryption: S3-managed (AES-256 server-side).
+    Versioning: enabled.
+    Public access: fully blocked.
+    Removal policy: retain on delete.
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        bucket_name: str | None = None,
+    ) -> None:
+        super().__init__(scope, construct_id)
+
+        # No naming helper exists in this repo; bucket_name
+        # is passed verbatim to the underlying Bucket.
+        bucket_kwargs: dict = {
+            "encryption": BucketEncryption.S3_MANAGED,
+            "versioned": True,
+            "block_public_access": BlockPublicAccess.BLOCK_ALL,
+            "removal_policy": RemovalPolicy.RETAIN,
+        }
+        if bucket_name is not None:
+            bucket_kwargs["bucket_name"] = bucket_name
+
+        self._bucket = Bucket(self, "Bucket", **bucket_kwargs)
+
+    @property
+    def bucket(self) -> Bucket:
+        """The underlying aws_cdk.aws_s3.Bucket instance."""
+        return self._bucket

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -1,0 +1,98 @@
+"""Tests for SecureBucket CDK construct."""
+
+from aws_cdk import App, Stack
+from aws_cdk.assertions import Template
+from aws_cdk.aws_s3 import Bucket
+
+from infiquetra_aws_infra.constructs.secure_bucket import SecureBucket
+
+
+def _make_stack_and_template(
+    bucket_name: str | None = None,
+) -> tuple[Stack, Template]:
+    """Create a minimal stack with SecureBucket and return (stack, template)."""
+    app = App()
+    stack = Stack(app, "TestStack")
+    kwargs: dict = {}
+    if bucket_name is not None:
+        kwargs["bucket_name"] = bucket_name
+    SecureBucket(stack, "TestBucket", **kwargs)
+    return stack, Template.from_stack(stack)
+
+
+def _find_bucket_resource(template: Template) -> dict:
+    """Find the single AWS::S3::Bucket resource in the template."""
+    buckets = template.find_resources("AWS::S3::Bucket")
+    assert len(buckets) == 1, f"Expected 1 bucket, found {len(buckets)}"
+    return next(iter(buckets.values()))
+
+
+def test_secure_bucket_uses_s3_managed_encryption() -> None:
+    """SecureBucket must use S3-managed server-side encryption."""
+    _, template = _make_stack_and_template()
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                    {
+                        "ServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256"
+                        }
+                    }
+                ]
+            }
+        },
+    )
+
+
+def test_secure_bucket_enables_versioning() -> None:
+    """SecureBucket must have versioning enabled."""
+    _, template = _make_stack_and_template()
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {"VersioningConfiguration": {"Status": "Enabled"}},
+    )
+
+
+def test_secure_bucket_blocks_all_public_access() -> None:
+    """SecureBucket must block all public access."""
+    _, template = _make_stack_and_template()
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": True,
+                "BlockPublicPolicy": True,
+                "IgnorePublicAcls": True,
+                "RestrictPublicBuckets": True,
+            }
+        },
+    )
+
+
+def test_secure_bucket_retains_bucket_on_delete() -> None:
+    """SecureBucket must have DeletionPolicy=Retain on the bucket."""
+    _, template = _make_stack_and_template()
+    bucket_resource = _find_bucket_resource(template)
+    assert bucket_resource.get("DeletionPolicy") == "Retain", (
+        f"Expected DeletionPolicy=Retain, "
+        f"got {bucket_resource.get('DeletionPolicy')}"
+    )
+
+
+def test_secure_bucket_exposes_wrapped_bucket() -> None:
+    """SecureBucket.bucket must return the underlying Bucket instance."""
+    app = App()
+    stack = Stack(app, "TestStack")
+    secure = SecureBucket(stack, "TestBucket")
+    assert isinstance(secure.bucket, Bucket)
+
+
+def test_secure_bucket_uses_verbatim_bucket_name_when_naming_helper_absent() -> None:
+    """When no naming helper exists, bucket_name is passed verbatim."""
+    _, template = _make_stack_and_template(bucket_name="my-exact-bucket-name")
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {"BucketName": "my-exact-bucket-name"},
+    )

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -1,5 +1,7 @@
 """Tests for SecureBucket CDK construct."""
 
+from typing import Any
+
 from aws_cdk import App, Stack
 from aws_cdk.assertions import Template
 from aws_cdk.aws_s3 import Bucket
@@ -13,7 +15,7 @@ def _make_stack_and_template(
     """Create a minimal stack with SecureBucket and return (stack, template)."""
     app = App()
     stack = Stack(app, "TestStack")
-    kwargs: dict = {}
+    kwargs: dict[str, Any] = {}
     if bucket_name is not None:
         kwargs["bucket_name"] = bucket_name
     SecureBucket(stack, "TestBucket", **kwargs)
@@ -78,6 +80,10 @@ def test_secure_bucket_retains_bucket_on_delete() -> None:
     assert bucket_resource.get("DeletionPolicy") == "Retain", (
         f"Expected DeletionPolicy=Retain, "
         f"got {bucket_resource.get('DeletionPolicy')}"
+    )
+    assert bucket_resource.get("UpdateReplacePolicy") == "Retain", (
+        f"Expected UpdateReplacePolicy=Retain, "
+        f"got {bucket_resource.get('UpdateReplacePolicy')}"
     )
 
 


### PR DESCRIPTION
## Linked card

Closes #30

## What changed

- Created `infiquetra_aws_infra/constructs/secure_bucket.py` — new `SecureBucket(Construct)` class that wraps `aws_cdk.aws_s3.Bucket` with secure defaults: S3-managed encryption, versioning enabled, all public access blocked, retain-on-delete removal policy. Exposes `.bucket` property. Accepts optional `bucket_name` verbatim (no `resource_name` helper exists in this repo).
- Created `infiquetra_aws_infra/constructs/__init__.py` — empty package init for new `constructs` subpackage.
- Created `tests/__init__.py` — empty package init for new `tests` directory.
- Created `tests/test_secure_bucket.py` — 6 named tests covering all acceptance criteria.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
pytest tests/test_secure_bucket.py
```

Output: `6 passed in 34.59s`

```bash
ruff check infiquetra_aws_infra/constructs/secure_bucket.py tests/test_secure_bucket.py
```

Output: `All checks passed!`

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): Covered. `SecureBucket.__init__(scope, construct_id, *, bucket_name=None)` in `secure_bucket.py` creates a `Bucket` with `encryption=BucketEncryption.S3_MANAGED`, `versioned=True`, `block_public_access=BlockPublicAccess.BLOCK_ALL`, `removal_policy=RemovalPolicy.RETAIN`. `.bucket` property returns the wrapped instance. `bucket_name` is passed verbatim when provided (no `resource_name` helper found in repo).
- AC 2 (All named tests pass the verification command): Covered. 6 tests in `test_secure_bucket.py` all pass: `test_secure_bucket_uses_s3_managed_encryption`, `test_secure_bucket_enables_versioning`, `test_secure_bucket_blocks_all_public_access`, `test_secure_bucket_retains_bucket_on_delete`, `test_secure_bucket_exposes_wrapped_bucket`, `test_secure_bucket_uses_verbatim_bucket_name_when_naming_helper_absent`.
- AC 3 (No dependencies added unless absolutely required): Covered. No dependency files were modified. All imports use existing repo dependencies.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated. Only `secure_bucket.py`, `test_secure_bucket.py`, and their necessary `__init__.py` package files were added.
- Do NOT add third-party dependencies unless required by the task body: not violated. No new dependencies.
- Do NOT refactor unrelated code in the touched files: not violated. All new files, no refactoring.

## Notes

- Repo search (`git grep -rn 'resource_name\|naming' -- '*.py'`) found no `resource_name` helper module. Per plan step 4, `bucket_name` is passed verbatim to the underlying `Bucket` when provided. The conditional `test_secure_bucket_uses_resource_name_when_naming_helper_available` was not added because no such helper was discovered.
- `__init__.py` files were added as necessary Python package infrastructure for the new `constructs/` subpackage and `tests/` directory — these are not "extra files" but standard Python module requirements.
- `test_secure_bucket_uses_verbatim_bucket_name_when_naming_helper_absent` confirms the synthesized `BucketName` matches the provided value exactly.

### Coverage

- "Implementation matches all behaviors described in the task body (see Notes)": ✓ addressed in `infiquetra_aws_infra/constructs/secure_bucket.py` (SecureBucket class + .bucket property)
- "All named tests pass the verification command": ✓ addressed in `tests/test_secure_bucket.py` (6 tests, all passing)
- "No dependencies added unless absolutely required": ✓ no dependency files modified
