### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,32 @@
+"""Common tagging utilities for AWS resources."""
+
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """Return standardized AWS resource tags.
+
+    Args:
+        env: Environment name (must be 'dev', 'staging', or 'prod').
+        team: Team name.
+        project: Project name.
+
+    Returns:
+        Dict with keys: Environment, Team, Project, ManagedBy.
+
+    Raises:
+        ValueError: If env is not one of 'dev', 'staging', or 'prod'.
+    """
+    normalized_env = env.strip()
+    normalized_team = team.strip()
+    normalized_project = project.strip()
+
+    if normalized_env not in {"dev", "staging", "prod"}:
+        raise ValueError(
+            f"env must be one of 'dev', 'staging', or 'prod', got '{normalized_env}'"
+        )
+
+    return {
+        "Environment": normalized_env,
+        "Team": normalized_team,
+        "Project": normalized_project,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,47 @@
+"""Tests for infiquetra_aws_infra.tagging.common_tags."""
+
+import pytest
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+class TestCommonTags:
+    """Tests for common_tags function."""
+
+    @pytest.mark.parametrize(
+        ("env", "team", "project"),
+        [
+            ("dev", "platform", "auth"),
+            ("staging", "backend", "api"),
+            ("prod", "frontend", "web"),
+        ],
+    )
+    def test_common_tags_accepts_valid_environments(
+        self, env: str, team: str, project: str
+    ) -> None:
+        """Valid environments (dev, staging, prod) should return correct tags."""
+        result = common_tags(env, team, project)
+
+        assert result["Environment"] == env
+        assert result["Team"] == team
+        assert result["Project"] == project
+        assert result["ManagedBy"] == "CDK"
+
+    def test_common_tags_rejects_invalid_environment(self) -> None:
+        """Invalid env values should raise ValueError."""
+        with pytest.raises(ValueError, match="env must be one of"):
+            common_tags("test", "x", "y")
+
+    def test_common_tags_normalizes_whitespace(self) -> None:
+        """Inputs with trailing/leading whitespace should be normalized."""
+        result = common_tags("dev  ", " platform ", "auth")
+
+        assert result["Environment"] == "dev"
+        assert result["Team"] == "platform"
+        assert result["Project"] == "auth"
+
+    def test_common_tags_returns_all_required_keys(self) -> None:
+        """Returned dict must contain exactly the required keys."""
+        result = common_tags("dev", "platform", "auth")
+
+        assert set(result.keys()) == {"Environment", "Team", "Project", "ManagedBy"}


### PR DESCRIPTION
## Linked card

Closes #36

## What changed

- Created `infiquetra_aws_infra/tagging.py` with `common_tags(env: str, team: str, project: str) -> dict[str, str]` helper
- Returns dict with keys: Environment, Team, Project, ManagedBy
- Validates env is one of 'dev', 'staging', 'prod', raises ValueError otherwise
- Normalizes all inputs with strip() to handle whitespace
- Created `tests/test_tagging.py` with 4 pytest test cases covering all requirements

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
source .venv/bin/activate
pytest tests/test_tagging.py -v
```

Results: **6 passed** (4 tests: valid environments, invalid env rejection, whitespace normalization, all keys present)

```bash
ruff check infiquetra_aws_infra/tagging.py tests/test_tagging.py
```

Results: **All checks passed!**

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): ✓ addressed in `infiquetra_aws_infra/tagging.py` (lines 7-38) - normalizes inputs with strip(), validates env against exact set {dev, staging, prod}, raises ValueError for invalid, returns exact required keys
- AC 2 (All named tests pass): ✓ addressed in `tests/test_tagging.py` - 6 tests pass, covering all behaviors from card
- AC 3 (No dependencies added): ✓ addressed - only stdlib features used (dict, strip, ValueError), no new deps introduced

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated (only tagging.py and tests/test_tagging.py created)
- Do NOT add third-party dependencies: not violated (no external deps added)
- Do NOT refactor unrelated code: not violated (no existing file modifications)

## Notes

- Implementation follows Python coding constitution for this repo (Python 3.13, ruff/pyright enabled)
- Tests validated with pytest 8.4.1 and ruff 0.12.5 from pyproject.toml dev dependencies
- No GitHub pull request template found