### PR TITLE
feat(naming): Add resource_name() builder for consistent AWS names

### DIFF
--- a/infiquetra_aws_infra/naming.py
+++ b/infiquetra_aws_infra/naming.py
@@ -1,0 +1,38 @@
+import re
+
+
+def resource_name(service: str, env: str, name: str, max_len: int = 64) -> str:
+    """
+    Builds a consistent AWS resource name.
+    Format: {service}-{env}-{name}
+    """
+    # Normalize to lowercase
+    service = service.lower()
+    env = env.lower()
+    name = name.lower()
+
+    # Validate components: non-empty and allowed characters [a-z0-9-]+
+    pattern = re.compile(r"^[a-z0-9-]+$")
+
+    for component, label in [(service, "service"), (env, "env"), (name, "name")]:
+        if not component:
+            raise ValueError(f"Component {label} cannot be empty")
+        if not pattern.match(component):
+            msg = f"Component {label} contains illegal characters: {component}"
+            raise ValueError(msg)
+
+    prefix = f"{service}-{env}-"
+    full_name = f"{prefix}{name}"
+
+    if len(full_name) <= max_len:
+        return full_name
+
+    # Truncate name component to fit max_len, preserving prefix
+    if len(prefix) >= max_len:
+        msg = f"Prefix '{prefix}' exceeds or equals max_len {max_len}"
+        raise ValueError(f"{msg}, no room for name component")
+
+    allowed_name_len = max_len - len(prefix)
+    truncated_name = name[:allowed_name_len]
+
+    return f"{prefix}{truncated_name}"

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,44 @@
+import pytest
+from infiquetra_aws_infra.naming import resource_name
+
+def test_resource_name_happy_path():
+    assert resource_name("s3", "dev", "user-data") == "s3-dev-user-data"
+
+def test_resource_name_truncates_name_to_max_len():
+    # prefix "lambda-prod-" is 12 chars. max_len 30. name should be 18 chars.
+    service = "lambda"
+    env = "prod"
+    long_name = "a" * 100
+    max_len = 30
+    result = resource_name(service, env, long_name, max_len=max_len)
+    
+    assert result.startswith(f"{service}-{env}-")
+    assert len(result) == max_len
+    # 30 - (6+1+4+1) = 30 - 12 = 18
+    assert result == f"lambda-prod-{'a' * 18}"
+
+def test_resource_name_rejects_empty_component():
+    with pytest.raises(ValueError, match="Component name cannot be empty"):
+        resource_name("s3", "dev", "")
+    with pytest.raises(ValueError, match="Component service cannot be empty"):
+        resource_name("", "dev", "user-data")
+    with pytest.raises(ValueError, match="Component env cannot be empty"):
+        resource_name("s3", "", "user-data")
+
+def test_resource_name_rejects_illegal_chars():
+    with pytest.raises(ValueError, match="Component name contains illegal characters"):
+        resource_name("s3", "dev", "Bad Name!")
+    with pytest.raises(ValueError, match="Component service contains illegal characters"):
+        resource_name("S3!", "dev", "user-data")
+    with pytest.raises(ValueError, match="Component env contains illegal characters"):
+        resource_name("s3", "dev@", "user-data")
+
+def test_resource_name_normalizes_case():
+    assert resource_name("S3", "Dev", "User-Data") == "s3-dev-user-data"
+    assert resource_name("s3", "DEV", "USER-DATA") == "s3-dev-user-data"
+
+def test_resource_name_prefix_too_long():
+    # prefix "verylongservice-verylongenv-" is 28 chars.
+    # if max_len is 20, it should raise ValueError.
+    with pytest.raises(ValueError, match="exceeds or equals max_len"):
+        resource_name("verylongservice", "verylongenv", "name", max_len=20)


### PR DESCRIPTION
## Linked card

Closes #40

## What changed

- Created \`infiquetra_aws_infra/naming.py\` with the \`resource_name\` function to build consistent, lowercased AWS resource names.
- Implemented validation for non-empty components and illegal characters (only \`a-z 0-9 -\` allowed).
- Implemented length truncation for the \`name\` component while preserving the \`{service}-{env}-\` prefix.
- Added \`tests/test_naming.py\` with full coverage for happy path, truncation, empty components, illegal characters, and case normalization.

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
PYTHONPATH=. pytest tests/test_naming.py -q
\`\`\`
Output: 6 passed in <1s.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors. Verified via \`tests/test_naming.py\`.
- AC 2: All named tests pass. Verified via pytest run.
- AC 3: No dependencies added. Only used standard \`re\` module.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: only \`infiquetra_aws_infra/naming.py\` and \`tests/test_naming.py\` were touched.
- Do NOT add third-party dependencies: none added.
- Do NOT refactor unrelated code: no unrelated changes made.

## Notes

- Added an extra test case \`test_resource_name_prefix_too_long\` to ensure that if the \`service-env-\` prefix itself exceeds \`max_len\`, it raises a \`ValueError\`.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in \`infiquetra_aws_infra/naming.py\`
- All named tests pass the verification command: ✓ addressed in \`tests/test_naming.py\`
- No dependencies added unless absolutely required: ✓ addressed in \`infiquetra_aws_infra/naming.py\`