### PR TITLE
feat(constructs): Add SecureBucket CDK construct with encryption + versioning

### DIFF
--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,0 +1,26 @@
+from aws_cdk import (
+    RemovalPolicy,
+)
+from aws_cdk import (
+    aws_s3 as s3,
+)
+from constructs import Construct
+
+
+class SecureBucket(Construct):
+    def __init__(self, scope, construct_id, *, bucket_name: str | None = None):
+        super().__init__(scope, construct_id)
+
+        self._bucket = s3.Bucket(
+            self,
+            "Bucket",
+            bucket_name=bucket_name,
+            encryption=s3.BucketEncryption.S3_MANAGED,
+            versioned=True,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+
+    @property
+    def bucket(self) -> s3.Bucket:
+        return self._bucket

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -1,0 +1,47 @@
+import pytest
+from aws_cdk import App, Stack, assertions
+from infiquetra_aws_infra.constructs.secure_bucket import SecureBucket
+
+@pytest.fixture
+def template():
+    app = App()
+    stack = Stack(app, "TestStack")
+    SecureBucket(stack, "SecureBucket")
+    return assertions.Template.from_stack(stack)
+
+def test_secure_bucket_uses_s3_managed_encryption(template):
+    template.has_resource_properties("AWS::S3::Bucket", {
+        "BucketEncryption": {
+            "ServerSideEncryptionConfiguration": [
+                {
+                    "ServerSideEncryptionByDefault": {
+                        "SSEAlgorithm": "AES256"
+                    }
+                }
+            ]
+        }
+    })
+
+def test_secure_bucket_enables_versioning(template):
+    template.has_resource_properties("AWS::S3::Bucket", {
+        "VersioningConfiguration": {
+            "Status": "Enabled"
+        }
+    })
+
+def test_secure_bucket_blocks_public_access(template):
+    template.has_resource_properties("AWS::S3::Bucket", {
+        "PublicAccessBlockConfiguration": {
+            "BlockPublicAcls": True,
+            "BlockPublicPolicy": True,
+            "IgnorePublicAcls": True,
+            "RestrictPublicBuckets": True
+        }
+    })
+
+def test_secure_bucket_retains_bucket_on_delete(template):
+    # DeletionPolicy and UpdateReplacePolicy are at the resource level, not in Properties
+    template.has_resource("AWS::S3::Bucket", {
+        "DeletionPolicy": "Retain",
+        "UpdateReplacePolicy": "Retain"
+    })


### PR DESCRIPTION
## Linked card

Closes #45

## What changed

- Created \`infiquetra_aws_infra/constructs/secure_bucket.py\` with \`SecureBucket\` construct.
- Implementation uses \`aws_cdk.aws_s3.Bucket\` with safe defaults: \`S3_MANAGED\` encryption, \`versioned=True\`, \`BLOCK_ALL\` public access, and \`RETAIN\` removal policy.
- Exposed underlying bucket via \`.bucket\` property.
- Implemented verbatim pass-through for optional \`bucket_name\`.
- Created \`tests/test_secure_bucket.py\` to verify synthesized CloudFormation properties.

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
source .venv/bin/activate
pytest tests/test_secure_bucket.py
\`\`\`
Output: 4 passed in 29.34s

## Acceptance criteria coverage

- AC 1: Implementation of \`SecureBucket\` in \`infiquetra_aws_infra/constructs/secure_bucket.py\` matches all described behaviors.
- AC 2: \`tests/test_secure_bucket.py\` passes verification.
- AC 3: No dependencies added; uses existing \`aws-cdk-lib\`, \`constructs\`, and \`pytest\`.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated.
- Do NOT add third-party dependencies: not violated.
- Do NOT refactor unrelated code: not violated.

## Notes

- The \`S3_MANAGED\` encryption in CDK synthesizes to \`AES256\` in the \`ServerSideEncryptionConfiguration\`. Tests were updated to match this synthesis.
- \`DeletionPolicy\` and \`UpdateReplacePolicy\` are resource-level attributes, so \`template.has_resource\` was used instead of \`template.has_resource_properties\`.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in \`infiquetra_aws_infra/constructs/secure_bucket.py\`
- All named tests pass the verification command: ✓ addressed in \`tests/test_secure_bucket.py\`
- No dependencies added unless absolutely required: ✓ addressed by using only existing project dependencies.