### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,36 @@
+"""Common tagging utilities for AWS resources."""
+
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """Return standardized AWS resource tags for the given environment.
+
+    Args:
+        env: The environment name (must be 'dev', 'staging', or 'prod').
+        team: The team name responsible for the resource.
+        project: The project name for the resource.
+
+    Returns:
+        A dictionary with the keys: Environment, Team, Project, and
+        ManagedBy.
+
+    Raises:
+        ValueError: If env is not one of 'dev', 'staging', or 'prod'.
+    """
+    # Normalize inputs by stripping leading/trailing whitespace
+    normalized_env = env.strip()
+    normalized_team = team.strip()
+    normalized_project = project.strip()
+
+    # Validate environment
+    if normalized_env not in ("dev", "staging", "prod"):
+        raise ValueError(
+            f"env must be one of 'dev', 'staging', or 'prod', got "
+            f"'{normalized_env}'"
+        )
+
+    return {
+        "Environment": normalized_env,
+        "Team": normalized_team,
+        "Project": normalized_project,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,87 @@
+"""Tests for the common_tags helper function."""
+
+import pytest
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+class TestCommonTags:
+    """Test cases for common_tags."""
+
+    @pytest.mark.parametrize(
+        ("env", "team", "project", "expected"),
+        [
+            (
+                "dev",
+                "platform",
+                "auth",
+                {
+                    "Environment": "dev",
+                    "Team": "platform",
+                    "Project": "auth",
+                    "ManagedBy": "CDK",
+                },
+            ),
+            (
+                "staging",
+                "platform",
+                "auth",
+                {
+                    "Environment": "staging",
+                    "Team": "platform",
+                    "Project": "auth",
+                    "ManagedBy": "CDK",
+                },
+            ),
+            (
+                "prod",
+                "platform",
+                "auth",
+                {
+                    "Environment": "prod",
+                    "Team": "platform",
+                    "Project": "auth",
+                    "ManagedBy": "CDK",
+                },
+            ),
+        ],
+    )
+    def test_valid_envs(
+        self,
+        env: str,
+        team: str,
+        project: str,
+        expected: dict[str, str],
+    ) -> None:
+        """Test that valid environments return the correct tag dictionary."""
+        result = common_tags(env, team, project)
+        assert result == expected
+
+    def test_invalid_env_raises_valueerror(self) -> None:
+        """Test that an invalid environment raises ValueError."""
+        with pytest.raises(ValueError):
+            common_tags("test", "x", "y")
+
+    def test_whitespace_normalization(self) -> None:
+        """Test that whitespace is stripped from all inputs."""
+        result = common_tags("dev  ", " platform ", "auth")
+        assert result == {
+            "Environment": "dev",
+            "Team": "platform",
+            "Project": "auth",
+            "ManagedBy": "CDK",
+        }
+
+    def test_all_required_keys_present(self) -> None:
+        """Test that all required keys are present in the returned dict."""
+        result = common_tags("dev", "platform", "auth")
+
+        # Check all required keys are present
+        required_keys = {"Environment", "Team", "Project", "ManagedBy"}
+        assert set(result.keys()) == required_keys
+
+        # Check specific values
+        assert result["Environment"] == "dev"
+        assert result["Team"] == "platform"
+        assert result["Project"] == "auth"
+        assert result["ManagedBy"] == "CDK"


### PR DESCRIPTION
## Linked card

Closes #49

## What changed

- Created  with  helper function
- Created  with pytest tests covering valid envs, invalid env, whitespace normalization, and required keys

## How verified

cd ~/workspace/infiquetra/infiquetra-aws-infra
.venv/bin/python -m pytest -v

Test output:
============================== 6 passed in 0.08s ===============================

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in infiquetra_aws_infra/tagging.py - implementation returns dict with exact keys Environment, Team, Project, ManagedBy='CDK', validates env against allowed values, and normalizes whitespace
- AC 2 (All named tests pass the verification command): ✓ addressed in tests/test_tagging.py - test_valid_envs (parametrized for dev/staging/prod), test_invalid_env_raises_valueerror, test_whitespace_normalization, and test_all_required_keys_present all pass

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only tagging.py and test_tagging.py added
- Do NOT add third-party dependencies unless required by the task body: not violated - no new dependencies added
- Do NOT refactor unrelated code in the touched files: not violated - new helper and test file added in isolation

## Notes

- The plan specified tests/test_tagging.py should exist in tests/, but the tests/ directory was empty on main; I added the test file there alongside the existing __pycache__/ directory
- The implementation follows Python coding conventions: fully typed public function, PEP 8 compliant (ruff check passes), pytest conventions with class-based tests
- The function uses only built-in Python behavior (str.strip(), dict literals, ValueError) - no external dependencies