### PR TITLE
feat(naming): Add resource_name() builder for consistent AWS names

### DIFF
--- a/infiquetra_aws_infra/naming.py
+++ b/infiquetra_aws_infra/naming.py
@@ -1,0 +1,46 @@
+import re
+
+
+def resource_name(service: str, env: str, name: str, max_len: int = 64) -> str:
+    """
+    Builds a consistent AWS resource name in the format {service}-{env}-{name}.
+
+    Args:
+        service: The AWS service name.
+        env: The environment name.
+        name: The specific resource name.
+        max_len: Maximum allowed length of the final string.
+
+    Returns:
+        A lowercased, validated, and potentially truncated resource name.
+
+    Raises:
+        ValueError: If any component is empty, contains illegal characters,
+                    or if max_len is too short to fit the required prefix.
+    """
+    service = service.lower()
+    env = env.lower()
+    name = name.lower()
+
+    if not service or not env or not name:
+        raise ValueError("All components (service, env, name) must be non-empty")
+
+    pattern = re.compile(r"^[a-z0-9-]+$")
+    if not all(pattern.match(c) for c in (service, env, name)):
+        raise ValueError(
+            "Components must only contain lowercase letters, numbers, and hyphens"
+        )
+
+    prefix = f"{service}-{env}-"
+    full_name = f"{prefix}{name}"
+
+    if len(full_name) <= max_len:
+        return full_name
+
+    if len(prefix) >= max_len:
+        raise ValueError(
+            f"max_len {max_len} is too short to accommodate the prefix '{prefix}'"
+        )
+
+    allowed_name_len = max_len - len(prefix)
+    return f"{prefix}{name[:allowed_name_len]}"

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,38 @@
+import pytest
+from infiquetra_aws_infra.naming import resource_name
+
+def test_resource_name_happy_path():
+    assert resource_name("s3", "dev", "user-data") == "s3-dev-user-data"
+
+def test_resource_name_truncates_name_to_max_len():
+    # prefix "lambda-prod-" is 12 chars. max_len 30. name should be 18 chars.
+    result = resource_name("lambda", "prod", "a" * 100, max_len=30)
+    assert len(result) == 30
+    assert result.startswith("lambda-prod-")
+    assert result == "lambda-prod-" + "a" * 18
+
+def test_resource_name_rejects_empty_component():
+    with pytest.raises(ValueError, match="must be non-empty"):
+        resource_name("", "dev", "user-data")
+    with pytest.raises(ValueError, match="must be non-empty"):
+        resource_name("s3", "", "user-data")
+    with pytest.raises(ValueError, match="must be non-empty"):
+        resource_name("s3", "dev", "")
+
+def test_resource_name_rejects_illegal_chars():
+    with pytest.raises(ValueError, match="only contain lowercase letters, numbers, and hyphens"):
+        resource_name("s3", "dev", "Bad Name!")
+    with pytest.raises(ValueError, match="only contain lowercase letters, numbers, and hyphens"):
+        resource_name("S3_Service", "dev", "user-data")
+
+def test_resource_name_normalizes_case():
+    assert resource_name("S3", "DEV", "USER-DATA") == "s3-dev-user-data"
+    assert resource_name("S3", "Dev", "uSeR-DaTa") == "s3-dev-user-data"
+
+def test_resource_name_prefix_too_long():
+    # prefix "longservice-production-" is 23 chars. max_len 20.
+    with pytest.raises(ValueError, match="too short to accommodate the prefix"):
+        resource_name("longservice", "production", "test", max_len=20)
+    # prefix "s3-dev-" is 7 chars. max_len 7.
+    with pytest.raises(ValueError, match="too short to accommodate the prefix"):
+        resource_name("s3", "dev", "test", max_len=7)


### PR DESCRIPTION
## Linked card

Closes #52

## What changed

- Implemented \`resource_name()\` in \`infiquetra_aws_infra/naming.py\` to build AWS resource names in the format \`{service}-{env}-{name}\`.
- Added validation for non-empty components and illegal characters (only \`a-z 0-9 -\` allowed).
- Implemented truncation logic that preserves the \`{service}-{env}-\` prefix and truncates only the \`name\` component to fit \`max_len\`.
- Added a guard to raise \`ValueError\` if the required prefix itself exceeds or equals \`max_len\`.
- Added a comprehensive test suite in \`tests/test_naming.py\` covering happy path, truncation, empty components, illegal characters, case normalization, and impossible length limits.

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
uv run pytest tests/test_naming.py
\`\`\`
Output: 6 passed in 0.01s

## Acceptance criteria coverage

- AC 1: Implementation matches mapping rules and handles truncation/errors in \`infiquetra_aws_infra/naming.py\`.
- AC 2: All 6 named tests in \`tests/test_naming.py\` passed.
- AC 3: No new dependencies added.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: only \`infiquetra_aws_infra/naming.py\` and \`tests/test_naming.py\` were modified.
- Do NOT add third-party dependencies: no new dependencies added.
- Do NOT refactor unrelated code: no unrelated changes made.

## Notes

The implementation explicitly handles the case where \`max_len\` is too small to fit the mandatory \`{service}-{env}-\` prefix, raising a \`ValueError\` as requested during plan review.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in \`infiquetra_aws_infra/naming.py\`
- All named tests pass the verification command: ✓ addressed in \`tests/test_naming.py\`
- No dependencies added unless absolutely required: ✓ addressed in \`pyproject.toml\` (no changes)