### PR TITLE
feat(naming): Add resource_name() builder for consistent AWS names

### DIFF
--- a/infiquetra_aws_infra/naming.py
+++ b/infiquetra_aws_infra/naming.py
@@ -1,0 +1,67 @@
+"""Resource naming utilities for AWS infrastructure."""
+import re
+
+# Module-level compiled regex for legal normalized components
+VALID_COMPONENT_RE = re.compile(r"^[a-z0-9-]+$")
+
+
+def resource_name(service: str, env: str, name: str, max_len: int = 64) -> str:
+    """Build a consistent AWS resource name.
+
+    Args:
+        service: The service/component name
+        env: The environment name
+        name: The specific resource name
+        max_len: Maximum length of the resulting name (default: 64)
+
+    Returns:
+        A formatted resource name: "{service}-{env}-{name}" lowercased
+
+    Raises:
+        ValueError: If any component is empty or contains illegal characters
+        (only a-z, 0-9, and - are allowed after normalization)
+    """
+    # Check for empty components before normalization
+    if not service:
+        raise ValueError("service component cannot be empty")
+    if not env:
+        raise ValueError("env component cannot be empty")
+    if not name:
+        raise ValueError("name component cannot be empty")
+
+    # Normalize to lowercase
+    normalized_service = service.lower()
+    normalized_env = env.lower()
+    normalized_name = name.lower()
+
+    # Validate each component against the regex
+    if not VALID_COMPONENT_RE.match(normalized_service):
+        raise ValueError(
+            f"service component contains illegal characters: {normalized_service!r}"
+        )
+    if not VALID_COMPONENT_RE.match(normalized_env):
+        raise ValueError(
+            f"env component contains illegal characters: {normalized_env!r}"
+        )
+    if not VALID_COMPONENT_RE.match(normalized_name):
+        raise ValueError(
+            f"name component contains illegal characters: {normalized_name!r}"
+        )
+
+    # Build the prefix and full resource name
+    prefix = f"{normalized_service}-{normalized_env}-"
+    candidate = f"{prefix}{normalized_name}"
+
+    # If within max_len, return as-is
+    if len(candidate) <= max_len:
+        return candidate
+
+    # Truncate the name component to fit within max_len
+    available_name_len = max_len - len(prefix)
+
+    if available_name_len <= 0:
+        raise ValueError(
+            f"Cannot fit required prefix '{prefix}' within max_len={max_len}"
+        )
+
+    return f"{prefix}{normalized_name[:available_name_len]}"

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,42 @@
+"""Tests for the naming module."""
+import pytest
+
+from infiquetra_aws_infra.naming import resource_name
+
+
+def test_resource_name_happy_path():
+    """Test the happy path for resource_name."""
+    result = resource_name("s3", "dev", "user-data")
+    assert result == "s3-dev-user-data"
+
+
+def test_resource_name_truncates_name_to_max_len():
+    """Test that resource_name truncates the name component when exceeding max_len."""
+    result = resource_name("lambda", "prod", "a" * 100, max_len=30)
+    assert result.startswith("lambda-prod-")
+    assert len(result) == 30
+    assert result == "lambda-prod-" + "a" * 18  # 30 - 12 (prefix length) = 18
+
+
+def test_resource_name_rejects_empty_component():
+    """Test that resource_name raises ValueError for empty components."""
+    with pytest.raises(ValueError):
+        resource_name("s3", "dev", "")
+
+    with pytest.raises(ValueError):
+        resource_name("", "dev", "user-data")
+
+    with pytest.raises(ValueError):
+        resource_name("s3", "", "user-data")
+
+
+def test_resource_name_rejects_illegal_chars():
+    """Test that resource_name raises ValueError for illegal characters."""
+    with pytest.raises(ValueError):
+        resource_name("s3", "dev", "Bad Name!")
+
+
+def test_resource_name_normalizes_case():
+    """Test that resource_name normalizes uppercase input to lowercase output."""
+    result = resource_name("S3", "Dev", "User-Data")
+    assert result == "s3-dev-user-data"


### PR DESCRIPTION
## Linked card

Closes #71

## What changed

- Created `infiquetra_aws_infra/naming.py` with `resource_name()` function that builds consistent AWS resource names
- Created `tests/test_naming.py` with comprehensive test coverage for all behaviors

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
pytest tests/test_naming.py -q
```

Output: `5 passed in 0.02s`

Also verified with:
```
ruff check infiquetra_aws_infra/naming.py tests/test_naming.py
# All checks passed!

mypy infiquetra_aws_infra/naming.py
# Success: no issues found in 1 source file
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes)
  - ✓ Addressed in `infiquetra_aws_infra/naming.py`
  - Format/lowercase behavior: `resource_name("s3", "dev", "user-data")` returns `"s3-dev-user-data"`
  - Truncation behavior: `resource_name("lambda", "prod", "a" * 100, max_len=30)` returns `"lambda-prod-" + "a" * 18`
  - Illegal character rejection: Raises `ValueError` for "Bad Name!"
  - Empty component rejection: Raises `ValueError` for empty service, env, or name
- AC 2: All named tests pass the verification command
  - ✓ Addressed in `tests/test_naming.py`
  - `test_resource_name_happy_path` - validates basic functionality
  - `test_resource_name_truncates_name_to_max_len` - validates truncation logic
  - `test_resource_name_rejects_empty_component` - validates empty input rejection
  - `test_resource_name_rejects_illegal_chars` - validates illegal char rejection
  - `test_resource_name_normalizes_case` - validates case normalization
- AC 3: No dependencies added unless absolutely required
  - ✓ Addressed - uses only standard library `re` module

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: Not violated - only `infiquetra_aws_infra/naming.py` and `tests/test_naming.py` added
- Do NOT add third-party dependencies unless required by the task body: Not violated - uses only `re` from stdlib
- Do NOT refactor unrelated code in the touched files: Not violated - only added new code

## Notes

Implementation follows the exact behaviors specified:
- Format: `"{service}-{env}-{name}"` lowercased
- Truncation: truncates the `name` component only, preserving `{service}-{env}-` prefix
- Validation: raises `ValueError` for empty components and illegal characters (only `a-z 0-9 -` allowed in output)
- Case normalization: converts uppercase input to lowercase output

Test coverage:
- Happy path: `resource_name("s3", "dev", "user-data")` returns `"s3-dev-user-data"`
- Truncation: `resource_name("lambda", "prod", "a" * 100, max_len=30)` returns truncated to 30 chars with prefix preserved
- Empty component: All three components raise `ValueError` when empty
- Illegal chars: `resource_name("s3", "dev", "Bad Name!")` raises `ValueError`
- Case normalization: `resource_name("S3", "Dev", "User-Data")` returns `"s3-dev-user-data"`
