### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,35 @@
+"""Standardized resource tagging utilities for AWS CDK stacks."""
+
+VALID_ENVIRONMENTS = {"dev", "staging", "prod"}
+
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """Return standardized AWS resource tags.
+
+    Args:
+        env: Environment name. Must be one of "dev", "staging", or "prod".
+        team: Team name.
+        project: Project name.
+
+    Returns:
+        Dictionary with Environment, Team, Project, and ManagedBy keys.
+
+    Raises:
+        ValueError: If env is not a valid environment.
+    """
+    normalized_env = env.strip()
+    normalized_team = team.strip()
+    normalized_project = project.strip()
+
+    if normalized_env not in VALID_ENVIRONMENTS:
+        valid_envs = ", ".join(sorted(VALID_ENVIRONMENTS))
+        raise ValueError(
+            f"Invalid environment '{normalized_env}'; expected one of: {valid_envs}"
+        )
+
+    return {
+        "Environment": normalized_env,
+        "Team": normalized_team,
+        "Project": normalized_project,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,45 @@
+"""Tests for common_tags helper."""
+
+import pytest
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+class TestCommonTagsValidEnvironments:
+    """Test that valid environments are accepted."""
+
+    @pytest.mark.parametrize("env", ["dev", "staging", "prod"])
+    def test_accepts_valid_environments(self, env: str) -> None:
+        """common_tags accepts dev, staging, and prod environments."""
+        tags = common_tags(env, "platform", "auth")
+        assert tags["Environment"] == env
+        assert tags["ManagedBy"] == "CDK"
+
+
+class TestCommonTagsInvalidEnvironment:
+    """Test that invalid environments raise ValueError."""
+
+    def test_rejects_invalid_environment(self) -> None:
+        """common_tags raises ValueError for invalid environment."""
+        with pytest.raises(ValueError, match="Invalid environment"):
+            common_tags("test", "x", "y")
+
+
+class TestCommonTagsWhitespaceNormalization:
+    """Test whitespace normalization on inputs."""
+
+    def test_normalizes_whitespace(self) -> None:
+        """common_tags strips leading and trailing whitespace."""
+        tags = common_tags("dev  ", " platform ", "auth")
+        assert tags["Environment"] == "dev"
+        assert tags["Team"] == "platform"
+        assert tags["Project"] == "auth"
+
+
+class TestCommonTagsRequiredKeys:
+    """Test that all required keys are present."""
+
+    def test_returns_all_required_keys(self) -> None:
+        """common_tags returns all required keys."""
+        tags = common_tags("dev", "platform", "auth")
+        assert set(tags) == {"Environment", "Team", "Project", "ManagedBy"}


### PR DESCRIPTION
## Linked card

Closes #67

## What changed

- Add `infiquetra_aws_infra/tagging.py` with `common_tags(env, team, project) -> dict[str, str]` function
- Add `tests/test_tagging.py` with 6 pytest test cases

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
.venv/bin/pytest tests/test_tagging.py -v
# Output: 6 passed in 0.08s

.venv/bin/pytest tests/ -q
# Output: 6 passed (full suite)

ruff check infiquetra_aws_infra/tagging.py tests/test_tagging.py
# Output: All checks passed!

mypy infiquetra_aws_infra/tagging.py tests/test_tagging.py
# Output: Success: no issues found in 2 source files
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body
  - `common_tags()` returns dict with Environment, Team, Project, ManagedBy keys
  - `ManagedBy` is hardcoded to "CDK"
  - `env` must be dev/staging/prod, raises ValueError otherwise
  - `.strip()` normalizes whitespace on all inputs
  - No external dependencies (uses only built-in types)

- AC 2: All named tests pass the verification command
  - `test_common_tags_accepts_valid_environments` (parametrized for dev/staging/prod)
  - `test_common_tags_rejects_invalid_environment`
  - `test_common_tags_normalizes_whitespace`
  - `test_common_tags_returns_all_required_keys`

- AC 3: No dependencies added unless absolutely required
  - No changes to pyproject.toml or dependency files
  - Implementation uses only Python built-ins

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `infiquetra_aws_infra/tagging.py` and `tests/test_tagging.py` touched
- Do NOT add third-party dependencies: not violated — no new dependencies
- Do NOT refactor unrelated code: not violated — both files are new, focused on `common_tags`

## Notes

- The `tests/` directory existed but was empty (only `__pycache__`), so test file was added directly
- Tests pass with `.venv/bin/pytest` (Python 3.13 venv) — the system pytest couldn't find the module due to environment differences

### Coverage

- [ ] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `infiquetra_aws_infra/tagging.py` lines 8-35 (common_tags function)
- [ ] All named tests pass the verification command: ✓ addressed in `tests/test_tagging.py` lines 1-45 (6 test methods)
- [ ] No dependencies added unless absolutely required: ✓ addressed — no pyproject.toml changes, only built-in types used