### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,20 @@
+ALLOWED_ENVIRONMENTS = {"dev", "staging", "prod"}
+
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    env = env.strip()
+    team = team.strip()
+    project = project.strip()
+
+    if env not in ALLOWED_ENVIRONMENTS:
+        expected = ", ".join(sorted(ALLOWED_ENVIRONMENTS))
+        raise ValueError(
+            f"Invalid environment '{env}'; expected one of: {expected}"
+        )
+
+    return {
+        "Environment": env,
+        "Team": team,
+        "Project": project,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,27 @@
+import pytest
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+@pytest.mark.parametrize("env", ["dev", "staging", "prod"])
+def test_common_tags_accepts_valid_environments(env: str) -> None:
+    result = common_tags(env, "platform", "auth")
+    assert result["Environment"] == env
+    assert result["ManagedBy"] == "CDK"
+
+
+def test_common_tags_rejects_invalid_environment() -> None:
+    with pytest.raises(ValueError, match="Invalid environment"):
+        common_tags("test", "x", "y")
+
+
+def test_common_tags_strips_whitespace() -> None:
+    result = common_tags("dev  ", " platform ", "auth")
+    assert result["Environment"] == "dev"
+    assert result["Team"] == "platform"
+    assert result["Project"] == "auth"
+
+
+def test_common_tags_returns_all_required_keys() -> None:
+    result = common_tags("prod", "platform", "auth")
+    assert set(result) == {"Environment", "Team", "Project", "ManagedBy"}


### PR DESCRIPTION
## Linked card

Closes #69

## What changed

- Created `infiquetra_aws_infra/tagging.py` with `common_tags(env, team, project)` helper.
- Validates `env` against `{"dev", "staging", "prod"}` and raises `ValueError` for invalid values.
- Strips whitespace from all input arguments.
- Returns a dict with keys `Environment`, `Team`, `Project`, `ManagedBy` where `ManagedBy` is always `"CDK"`.
- Added `tests/test_tagging.py` with four pytest cases covering valid environments, invalid environment error, whitespace normalization, and required keys presence.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
PYTHONPATH=. pytest tests/test_tagging.py -v
```

Output:
```
tests/test_tagging.py::test_common_tags_accepts_valid_environments[dev] PASSED
tests/test_tagging.py::test_common_tags_accepts_valid_environments[staging] PASSED
tests/test_tagging.py::test_common_tags_accepts_valid_environments[prod] PASSED
tests/test_tagging.py::test_common_tags_rejects_invalid_environment PASSED
tests/test_tagging.py::test_common_tags_strips_whitespace PASSED
tests/test_tagging.py::test_common_tags_returns_all_required_keys PASSED

============================== 6 passed in 0.02s ===============================
```

Also ran `ruff check` (0 errors) and `pyright` (0 errors) on both modified files.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): Covered by `infiquetra_aws_infra/tagging.py` — exact signature, validation, normalization, and returned keys.
- AC 2 (All named tests pass the verification command): Covered by `tests/test_tagging.py` — all six named tests pass under pytest.
- AC 3 (No dependencies added unless absolutely required): Covered — no new dependencies added; implementation uses only Python built-ins.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: Not violated. Only `infiquetra_aws_infra/tagging.py` and `tests/test_tagging.py` were changed.
- Do NOT add third-party dependencies unless required by the task body: Not violated. No new dependencies introduced.
- Do NOT refactor unrelated code in the touched files: Not violated. Both files are new.

## Notes

None.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `infiquetra_aws_infra/tagging.py` (`common_tags`)
- AC 2 (All named tests pass the verification command): ✓ addressed in `tests/test_tagging.py`
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — no dependency changes
