### PR TITLE
feat(constructs): add SecureBucket construct with encryption + versioning

### DIFF
--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,0 +1,46 @@
+from aws_cdk import RemovalPolicy
+from aws_cdk.aws_s3 import BlockPublicAccess, Bucket, BucketEncryption
+from constructs import Construct
+
+
+class SecureBucket(Construct):
+    """
+    CDK construct that wraps an S3 Bucket with secure defaults.
+    """
+
+    def __init__(
+        self, scope: Construct, construct_id: str, *, bucket_name: str | None = None
+    ) -> None:
+        super().__init__(scope, construct_id)
+
+        # Optional validation via naming.resource_name if available
+        if bucket_name is not None:
+            try:
+                from infiquetra_aws_infra.naming import resource_name
+
+                # Validation probe: ensure the bucket name is valid for 's3' service
+                # If it raises ValueError or returns non-string/empty, it fails
+                validated_name = resource_name("s3", "secure", bucket_name, max_len=63)
+                if not validated_name or not isinstance(validated_name, str):
+                    raise ValueError(f"Invalid bucket name provided: {bucket_name}")
+            except ImportError:
+                # If naming.resource_name is unavailable, accept verbatim
+                pass
+            except ValueError as e:
+                # Re-raise validation errors to fail the constructor
+                raise e
+
+        self._bucket = Bucket(
+            self,
+            "Bucket",
+            bucket_name=bucket_name,
+            encryption=BucketEncryption.S3_MANAGED,
+            versioned=True,
+            block_public_access=BlockPublicAccess.BLOCK_ALL,
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+
+    @property
+    def bucket(self) -> Bucket:
+        """Exposes the underlying S3 Bucket."""
+        return self._bucket

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -1,0 +1,56 @@
+import pytest
+from aws_cdk import App, Stack
+from aws_cdk.assertions import Template
+from infiquetra_aws_infra.constructs.secure_bucket import SecureBucket
+
+def _template_for(bucket_name: str | None = None) -> Template:
+    app = App()
+    stack = Stack(app, "TestStack")
+    SecureBucket(stack, "SecureBucket", bucket_name=bucket_name)
+    return Template.from_stack(stack)
+
+def test_secure_bucket_applies_encryption_versioning_and_public_access_block():
+    template = _template_for()
+    
+    template.has_resource_properties("AWS::S3::Bucket", {
+        "BucketEncryption": {
+            "ServerSideEncryptionConfiguration": [
+                {
+                    "ServerSideEncryptionByDefault": {
+                        "SSEAlgorithm": "AES256"
+                    }
+                }
+            ]
+        },
+        "VersioningConfiguration": {
+            "Status": "Enabled"
+        },
+        "PublicAccessBlockConfiguration": {
+            "BlockPublicAcls": True,
+            "BlockPublicPolicy": True,
+            "IgnorePublicAcls": True,
+            "RestrictPublicBuckets": True
+        }
+    })
+
+def test_secure_bucket_uses_retain_removal_policy():
+    template = _template_for()
+    resources = template.to_json()["Resources"]
+    
+    # Find the S3 Bucket resource
+    buckets = [res for res in resources.values() if res["Type"] == "AWS::S3::Bucket"]
+    
+    if len(buckets) != 1:
+        pytest.fail(f"Expected exactly 1 S3 Bucket resource, found {len(buckets)}")
+    
+    bucket = buckets[0]
+    assert bucket.get("DeletionPolicy") == "Retain"
+    assert bucket.get("UpdateReplacePolicy") == "Retain"
+
+def test_secure_bucket_uses_explicit_bucket_name_when_provided():
+    bucket_name = "s3-secure-user-data"
+    template = _template_for(bucket_name=bucket_name)
+    
+    template.has_resource_properties("AWS::S3::Bucket", {
+        "BucketName": bucket_name
+    })


### PR DESCRIPTION
## Linked card

Closes #72

## What changed

- Created infiquetra_aws_infra/constructs/secure_bucket.py implementing SecureBucket(Construct).
- Implemented secure defaults: encryption=S3_MANAGED, versioned=True, block_public_access=BLOCK_ALL, and removal_policy=RETAIN.
- Added optional bucket_name support with a validation probe using infiquetra_aws_infra.naming.resource_name (if available).
- Exposed the underlying Bucket via the .bucket property.
- Created tests/test_secure_bucket.py to verify CloudFormation output for encryption, versioning, public access blocks, and removal policy.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
uv run pytest tests/test_secure_bucket.py
```
Output: 3 passed in 37.78s

## Acceptance criteria coverage

- AC 1: Implementation of SecureBucket with specified defaults and .bucket property in infiquetra_aws_infra/constructs/secure_bucket.py. Verified by tests/test_secure_bucket.py.
- AC 2: All tests passed via uv run pytest tests/test_secure_bucket.py.
- AC 3: No new dependencies added; used existing aws-cdk-lib and constructs.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated (only touched infiquetra_aws_infra/constructs/secure_bucket.py and tests/test_secure_bucket.py).
- Do NOT add third-party dependencies: not violated.
- Do NOT refactor unrelated code: not violated.

## Notes

The infiquetra_aws_infra/naming.py file mentioned in the approved plan was not present in the repository's main branch at the time of implementation. As per the requirements ("else accepts verbatim"), the construct handles the absence of the naming helper gracefully and accepts the bucket_name verbatim.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in infiquetra_aws_infra/constructs/secure_bucket.py
- All named tests pass the verification command: ✓ addressed in tests/test_secure_bucket.py
- No dependencies added unless absolutely required: ✓ addressed in pyproject.toml (no change)