### PR TITLE
feat(constructs): Add SecureBucket CDK construct with encryption + versioning

### DIFF
--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,0 +1,46 @@
+"""Secure S3 bucket construct with safe defaults."""
+
+from aws_cdk import RemovalPolicy
+from aws_cdk.aws_s3 import BlockPublicAccess, Bucket, BucketEncryption
+from constructs import Construct
+
+
+def _resolve_bucket_name(bucket_name: str | None) -> str | None:
+    """Normalize bucket name via naming.resource_name if available."""
+    if bucket_name is None:
+        return None
+    try:
+        from infiquetra_aws_infra import naming
+    except ModuleNotFoundError:
+        return bucket_name
+    if hasattr(naming, "resource_name") and callable(naming.resource_name):
+        return naming.resource_name(bucket_name)
+    return bucket_name
+
+
+class SecureBucket(Construct):
+    """CDK construct wrapping S3 Bucket with secure defaults."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        bucket_name: str | None = None,
+    ) -> None:
+        super().__init__(scope, construct_id)
+
+        self._bucket = Bucket(
+            self,
+            "Bucket",
+            bucket_name=_resolve_bucket_name(bucket_name),
+            encryption=BucketEncryption.S3_MANAGED,
+            versioned=True,
+            block_public_access=BlockPublicAccess.BLOCK_ALL,
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+
+    @property
+    def bucket(self) -> Bucket:
+        """Return the underlying S3 Bucket resource."""
+        return self._bucket

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -1,0 +1,65 @@
+"""Unit tests for SecureBucket CDK construct."""
+
+import pytest
+from aws_cdk import App, Stack
+from aws_cdk.assertions import Template
+
+from infiquetra_aws_infra.constructs.secure_bucket import SecureBucket
+
+
+@pytest.fixture
+def template() -> Template:
+    """Create CloudFormation template from SecureBucket synth."""
+    app = App()
+    stack = Stack(app, "TestStack")
+    SecureBucket(stack, "SecureBucket")
+    return Template.from_stack(stack)
+
+
+def test_secure_bucket_uses_s3_managed_encryption(template: Template) -> None:
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                    {"ServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}
+                ]
+            }
+        },
+    )
+
+
+def test_secure_bucket_enables_versioning(template: Template) -> None:
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {"VersioningConfiguration": {"Status": "Enabled"}},
+    )
+
+
+def test_secure_bucket_blocks_public_access(template: Template) -> None:
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": True,
+                "BlockPublicPolicy": True,
+                "IgnorePublicAcls": True,
+                "RestrictPublicBuckets": True,
+            }
+        },
+    )
+
+
+def test_secure_bucket_retains_on_delete(template: Template) -> None:
+    buckets = template.find_resources("AWS::S3::Bucket")
+    assert len(buckets) == 1
+    bucket = next(iter(buckets.values()))
+    assert bucket.get("DeletionPolicy") == "Retain"
+    assert bucket.get("UpdateReplacePolicy") == "Retain"
+
+
+def test_secure_bucket_exposes_underlying_bucket() -> None:
+    app = App()
+    stack = Stack(app, "TestStack2")
+    secure_bucket = SecureBucket(stack, "SecureBucket2")
+    assert secure_bucket.bucket is secure_bucket._bucket


### PR DESCRIPTION
## Linked card

Closes #83

## What changed

- Created `infiquetra_aws_infra/constructs/secure_bucket.py` with a new `SecureBucket` CDK construct wrapping `aws_cdk.aws_s3.Bucket`.
- Implemented `_resolve_bucket_name` helper to apply `naming.resource_name` when the module is available, otherwise accept the name verbatim.
- Set secure defaults: `BucketEncryption.S3_MANAGED`, `versioned=True`, `BlockPublicAccess.BLOCK_ALL`, and `removal_policy=RemovalPolicy.RETAIN`.
- Added read-only `.bucket` property exposing the underlying `Bucket`.
- Created `tests/test_secure_bucket.py` with five named tests asserting encryption, versioning, public-access blocking, retain-on-delete policy, and property access.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
.venv/bin/python -m pytest tests/test_secure_bucket.py -q
```
Output: 5 passed in ~18s

```bash
.venv/bin/python -m pytest -q
```
Output: 5 passed (no other tests in repo)

## Acceptance criteria coverage

- **Implementation matches all behaviors described in the task body ✅**
  - `SecureBucket(Construct)` with correct signature in `secure_bucket.py`
  - Underlying `Bucket` uses `S3_MANAGED`, `versioned=True`, `BlockPublicAccess.BLOCK_ALL`, `RemovalPolicy.RETAIN`
  - `.bucket` property exposes the underlying `Bucket`
  - Optional `bucket_name` handled with `_resolve_bucket_name` fallback
- **All named tests pass the verification command ✅**
  - `test_secure_bucket_uses_s3_managed_encryption`
  - `test_secure_bucket_enables_versioning`
  - `test_secure_bucket_blocks_public_access`
  - `test_secure_bucket_retains_on_delete`
  - `test_secure_bucket_exposes_underlying_bucket`
- **No dependencies added unless absolutely required ✅**
  - No changes to `pyproject.toml`, `requirements.txt`, or lock files

## Non-goals acknowledged

- **Do NOT modify files beyond the expected set below**: Acknowledged. Diff only touches `infiquetra_aws_infra/constructs/secure_bucket.py` and `tests/test_secure_bucket.py`.
- **Do NOT add third-party dependencies unless required by the task body**: Acknowledged. No new dependencies were added.
- **Do NOT refactor unrelated code in the touched files**: Acknowledged. Both files are new and only contain the work described in the card.

## Notes

- None

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body (see Notes)): ✓ addressed in `infiquetra_aws_infra/constructs/secure_bucket.py` class `SecureBucket` and `tests/test_secure_bucket.py`
- AC 2 (All named tests pass the verification command): ✓ addressed in `tests/test_secure_bucket.py` (`test_secure_bucket_uses_s3_managed_encryption`, `test_secure_bucket_enables_versioning`, `test_secure_bucket_blocks_public_access`, `test_secure_bucket_retains_on_delete`, `test_secure_bucket_exposes_underlying_bucket`)
- AC 3 (No dependencies added unless absolutely required): ✓ addressed; zero dependency file changes