### PR TITLE
feat(naming): Add resource_name() builder for consistent AWS names

### DIFF
--- a/infiquetra_aws_infra/naming.py
+++ b/infiquetra_aws_infra/naming.py
@@ -1,0 +1,73 @@
+"""AWS resource naming utilities."""
+
+import re
+
+_VALID_NAME_RE = re.compile(r"^[a-z0-9-]+$")
+
+
+def resource_name(
+    service: str,
+    env: str,
+    name: str,
+    max_len: int = 64,
+) -> str:
+    """Build a lowercased AWS resource name with ``{service}-{env}-{name}`` format.
+
+    Parameters
+    ----------
+    service:
+        Service name component (e.g. ``"s3"``, ``"lambda"``).
+    env:
+        Environment component (e.g. ``"dev"``, ``"prod"``).
+    name:
+        Logical resource name.
+    max_len:
+        Maximum length of the returned string.  Default 64.
+
+    Returns
+    -------
+    str
+        Lowercased name string no longer than ``max_len``.
+
+    Raises
+    ------
+    ValueError
+        If any component is empty, or contains characters outside
+        ``[a-z0-9-]`` after lowercasing.
+    """
+    if not service:
+        raise ValueError("service component is empty")
+    if not env:
+        raise ValueError("env component is empty")
+    if not name:
+        raise ValueError("name component is empty")
+
+    service_lower = service.lower()
+    env_lower = env.lower()
+    name_lower = name.lower()
+
+    for label, value in [
+        ("service", service_lower),
+        ("env", env_lower),
+        ("name", name_lower),
+    ]:
+        if not _VALID_NAME_RE.fullmatch(value):
+            raise ValueError(
+                f"{label} contains illegal characters "
+                f"(only a-z, 0-9, and hyphens allowed): {value!r}"
+            )
+
+    prefix = f"{service_lower}-{env_lower}-"
+    candidate = f"{prefix}{name_lower}"
+
+    if len(candidate) <= max_len:
+        return candidate
+
+    allowed_name_len = max_len - len(prefix)
+    if allowed_name_len < 1:
+        raise ValueError(
+            f"max_len={max_len} is too small to hold "
+            f"prefix {prefix!r} and a non-empty name"
+        )
+
+    return f"{prefix}{name_lower[:allowed_name_len]}"

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,34 @@
+import pytest
+
+from infiquetra_aws_infra.naming import resource_name
+
+
+def test_resource_name_happy_path() -> None:
+    assert resource_name("s3", "dev", "user-data") == "s3-dev-user-data"
+
+
+def test_resource_name_truncates_name_to_max_len() -> None:
+    result = resource_name("lambda", "prod", "a" * 100, max_len=30)
+    assert len(result) == 30
+    assert result.startswith("lambda-prod-")
+    assert result == "lambda-prod-" + "a" * (30 - len("lambda-prod-"))
+
+
+@pytest.mark.parametrize(
+    "service,env,name",
+    [("", "dev", "x"), ("s3", "", "x"), ("s3", "dev", "")],
+)
+def test_resource_name_rejects_empty_component(
+    service: str, env: str, name: str
+) -> None:
+    with pytest.raises(ValueError):
+        resource_name(service, env, name)
+
+
+def test_resource_name_rejects_illegal_chars() -> None:
+    with pytest.raises(ValueError):
+        resource_name("s3", "dev", "Bad Name!")
+
+
+def test_resource_name_lowercases_components() -> None:
+    assert resource_name("S3", "Dev", "User-Data") == "s3-dev-user-data"


### PR DESCRIPTION
## Linked card

Closes #88

## What changed

- Created `infiquetra_aws_infra/naming.py` with `resource_name(service, env, name, max_len=64)` function that builds lowercased `{service}-{env}-{name}` AWS resource names.
- Created `tests/test_naming.py` with 5 test functions covering happy path, length truncation, empty component rejection, illegal character rejection, and case normalization.

## How verified

```
cd ~/workspace/infiquetra/infiquetra-aws-infra && .venv/bin/python -m pytest tests/test_naming.py -v
```

Output:
```
collected 7 items

tests/test_naming.py .......                                             [100%]

============================== 7 passed in 0.05s ==============================
```

Additional: `ruff check` passes clean, `mypy` reports no issues on both files.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — covered by `infiquetra_aws_infra/naming.py` (empty component rejection, illegal char validation, lowercasing, length truncation preserving prefix)
- AC 2: All named tests pass the verification command — covered by `tests/test_naming.py` (7 pytest cases, all green)
- AC 3: No dependencies added unless absolutely required — only stdlib `re` used, no changes to packaging files

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below — only `infiquetra_aws_infra/naming.py` and `tests/test_naming.py` were created
- Do NOT add third-party dependencies — none added (only stdlib `re` plus existing pytest)
- Do NOT refactor unrelated code — no existing files were modified

## Notes

No deviations from the approved plan. The implementation follows the exact approach: stdlib-only, regex-based validation, prefix-preserving truncation, and explicit ValueError messages for empty/illegal inputs.

### Coverage

- [ ] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `infiquetra_aws_infra/naming.py` (resource_name function)
- [ ] All named tests pass the verification command: ✓ addressed in `tests/test_naming.py` (5 test functions, 7 parametrized cases)
- [ ] No dependencies added unless absolutely required: ✓ addressed — only stdlib `re` used, no packaging changes