### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,32 @@
+VALID_ENVIRONMENTS = {"dev", "staging", "prod"}
+
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """Return standardized resource tags for AWS infrastructure.
+
+    Args:
+        env: Environment name (dev, staging, prod).
+        team: Team name.
+        project: Project name.
+
+    Returns:
+        Dictionary with keys: Environment, Team, Project, ManagedBy.
+
+    Raises:
+        ValueError: If environment is not one of the valid values.
+    """
+    normalized_env = env.strip()
+    normalized_team = team.strip()
+    normalized_project = project.strip()
+
+    if normalized_env not in VALID_ENVIRONMENTS:
+        allowed = "', '".join(sorted(VALID_ENVIRONMENTS))
+        msg = f"Invalid env: expected [{allowed}], got '{normalized_env}'"
+        raise ValueError(msg)
+
+    return {
+        "Environment": normalized_env,
+        "Team": normalized_team,
+        "Project": normalized_project,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,42 @@
+"""Tests for infiquetra_aws_infra.tagging."""
+
+import pytest
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+class TestCommonTags:
+    """Test suite for common_tags function."""
+
+    @pytest.mark.parametrize(
+        "environment",
+        ["dev", "staging", "prod"],
+    )
+    def test_common_tags_accepts_valid_environments(
+        self,
+        environment: str,
+    ) -> None:
+        """Test that valid environments are accepted."""
+        result = common_tags(environment, "platform", "auth")
+
+        assert result["Environment"] == environment
+        assert result["ManagedBy"] == "CDK"
+
+    def test_common_tags_rejects_invalid_environment(self) -> None:
+        """Test that invalid environments raise ValueError."""
+        with pytest.raises(ValueError):
+            common_tags("test", "x", "y")
+
+    def test_common_tags_strips_whitespace(self) -> None:
+        """Test that whitespace is stripped from all inputs."""
+        result = common_tags("dev  ", " platform ", "auth")
+
+        assert result["Environment"] == "dev"
+        assert result["Team"] == "platform"
+        assert result["Project"] == "auth"
+
+    def test_common_tags_returns_all_required_keys(self) -> None:
+        """Test that all required keys are present in the result."""
+        result = common_tags("dev", "platform", "auth")
+
+        assert set(result.keys()) == {"Environment", "Team", "Project", "ManagedBy"}


### PR DESCRIPTION
## Linked card

Closes #91

## What changed

- Added `infiquetra_aws_infra/tagging.py` with `common_tags(env: str, team: str, project: str) -> dict[str, str]` helper
- Added standardized tag dictionary with keys: Environment, Team, Project, ManagedBy
- Validates environment against allowed values (dev, staging, prod), raises ValueError on invalid input
- Strips whitespace from all inputs before validation/return
- Added `tests/test_tagging.py` with pytest tests for valid environments, ValueError for bad env, whitespace normalization, and all required keys present

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
# Language-appropriate test command (flutter test / pytest / etc.)
.venv/bin/python -m pytest tests/test_tagging.py

============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/agent/workspace/infiquetra/infiquetra-aws-infra
configfile: pyproject.toml
plugins: anyio-4.9.0, typeguard-2.13.3
collected 6 items

tests/test_tagging.py ......                                             [100%]

============================== 6 passed in 0.10s ===============================
```

- Ruff check passes with zero errors on modified files
- No new dependencies added (uses only stdlib features)

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `infiquetra_aws_infra/tagging.py` via `common_tags()` function which validates environments, normalizes whitespace, and returns standardized tags
- AC 2 (All named tests pass the verification command): ✓ addressed in `tests/test_tagging.py` with pytest tests `test_common_tags_accepts_valid_environments`, `test_common_tags_rejects_invalid_environment`, `test_common_tags_strips_whitespace`, `test_common_tags_returns_all_required_keys`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only `infiquetra_aws_infra/tagging.py` and `tests/test_tagging.py` were created/modified
- Do NOT add third-party dependencies unless required by the task body: not violated - no new dependencies added, uses only stdlib
- Do NOT refactor unrelated code in the touched files: not violated - new files created, no existing code modified

## Notes

### Coverage

- AC 1 (verbatim): ✓ addressed in `infiquetra_aws_infra/tagging.py` - `common_tags()` function implements validation, normalization, and return structure as specified
- AC 2 (verbatim): ✓ addressed in `tests/test_tagging.py` - 4 test functions cover all named cases from task body