### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,22 @@
+ALLOWED_ENVIRONMENTS = {"dev", "staging", "prod"}
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """
+    Returns a standardized dictionary of tags for AWS resources.
+    """
+    normalized_env = env.strip()
+    normalized_team = team.strip()
+    normalized_project = project.strip()
+
+    if normalized_env not in ALLOWED_ENVIRONMENTS:
+        raise ValueError(
+            f"Invalid environment: expected one of "
+            f"dev, staging, prod; got {normalized_env!r}"
+        )
+
+    return {
+        "Environment": normalized_env,
+        "Team": normalized_team,
+        "Project": normalized_project,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,27 @@
+import pytest
+from infiquetra_aws_infra.tagging import common_tags
+
+@pytest.mark.parametrize("env", ["dev", "staging", "prod"])
+def test_common_tags_accepts_valid_environments(env):
+    tags = common_tags(env, "platform", "auth")
+    assert tags["Environment"] == env
+    assert tags["Team"] == "platform"
+    assert tags["Project"] == "auth"
+    assert tags["ManagedBy"] == "CDK"
+
+def test_common_tags_rejects_invalid_environment():
+    with pytest.raises(ValueError, match="Invalid environment"):
+        common_tags("test", "x", "y")
+
+def test_common_tags_strips_whitespace_from_inputs():
+    expected = {
+        "Environment": "dev",
+        "Team": "platform",
+        "Project": "auth",
+        "ManagedBy": "CDK",
+    }
+    assert common_tags("dev  ", " platform ", "auth") == expected
+
+def test_common_tags_returns_all_required_keys():
+    tags = common_tags("prod", "platform", "billing")
+    assert set(tags.keys()) == {"Environment", "Team", "Project", "ManagedBy"}


### PR DESCRIPTION
## Linked card

Closes #94

## What changed

- Created \`infiquetra_aws_infra/tagging.py\` containing the \`common_tags\` helper function.
- Implemented \`common_tags\` to return a dictionary with \`Environment\`, \`Team\`, \`Project\`, and \`ManagedBy\` keys.
- Added validation for \`env\` ensuring it is one of \`dev\`, \`staging\`, or \`prod\`, raising \`ValueError\` otherwise.
- Implemented whitespace stripping for all input strings.
- Created \`tests/test_tagging.py\` with pytest cases for valid environments, invalid environments, whitespace normalization, and key presence.

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
source venv/bin/activate
PYTHONPATH=. pytest tests/test_tagging.py -q
\`\`\`

Output:
...... [100%]

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body. ✓ addressed in \`infiquetra_aws_infra/tagging.py\`'s \`common_tags\` function.
- AC 2: All named tests pass the verification command. ✓ addressed in \`tests/test_tagging.py\`.
- AC 3: No dependencies added unless absolutely required. ✓ used only Python standard library and existing pytest.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated (only modified \`infiquetra_aws_infra/tagging.py\` and \`tests/test_tagging.py\`).
- Do NOT add third-party dependencies unless required by the task body: not violated.
- Do NOT refactor unrelated code in the touched files: not violated.

## Notes

None.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in infiquetra_aws_infra/tagging.py
- All named tests pass the verification command: ✓ addressed in tests/test_tagging.py
- No dependencies added unless absolutely required: ✓ addressed in infiquetra_aws_infra/tagging.py