### PR TITLE
feat(constructs): Add SecureBucket CDK construct with encryption + versioning

### DIFF
--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,0 +1,44 @@
+"""SecureBucket CDK construct with safe S3 defaults."""
+
+from aws_cdk import RemovalPolicy
+from aws_cdk.aws_s3 import BlockPublicAccess, Bucket, BucketEncryption
+from constructs import Construct
+
+
+class SecureBucket(Construct):
+    """S3 Bucket with encryption, versioning, public-access blocking, retain policy."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        bucket_name: str | None = None,
+    ) -> None:
+        super().__init__(scope, construct_id)
+
+        validated_bucket_name = bucket_name
+
+        # Optional validation via naming.resource_name if available
+        try:
+            from infiquetra_aws_infra.naming import resource_name
+
+            if bucket_name is not None:
+                resource_name("s3", "bucket", bucket_name, max_len=63)
+        except ImportError:
+            pass
+
+        self._bucket = Bucket(
+            self,
+            "Bucket",
+            bucket_name=validated_bucket_name,
+            encryption=BucketEncryption.S3_MANAGED,
+            versioned=True,
+            block_public_access=BlockPublicAccess.BLOCK_ALL,
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+
+    @property
+    def bucket(self) -> Bucket:
+        """Expose the underlying S3 Bucket resource."""
+        return self._bucket

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -1,0 +1,65 @@
+"""Tests for SecureBucket CDK construct."""
+
+import aws_cdk as cdk
+from aws_cdk.assertions import Template
+
+from infiquetra_aws_infra.constructs.secure_bucket import SecureBucket
+
+
+def test_secure_bucket_synthesizes_safe_bucket_defaults() -> None:
+    """SecureBucket synthesizes with encryption, versioning, access block, retain."""
+    app = cdk.App()
+    stack = cdk.Stack(app, "TestStack")
+    secure_bucket = SecureBucket(stack, "SecureBucket")
+
+    assert secure_bucket.bucket is not None
+
+    template = Template.from_stack(stack)
+
+    # Verify encryption (S3_MANAGED -> AES256 in CloudFormation)
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                    {
+                        "ServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256",
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+    # Verify versioning enabled
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "VersioningConfiguration": {
+                "Status": "Enabled",
+            },
+        },
+    )
+
+    # Verify block public access
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": True,
+                "BlockPublicPolicy": True,
+                "IgnorePublicAcls": True,
+                "RestrictPublicBuckets": True,
+            },
+        },
+    )
+
+    # Verify retain-on-delete policy
+    template.has_resource(
+        "AWS::S3::Bucket",
+        {
+            "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
+        },
+    )


### PR DESCRIPTION
## Linked card

Closes #89

## What changed

- Add `SecureBucket` construct at `infiquetra_aws_infra/constructs/secure_bucket.py` that wraps `aws_cdk.aws_s3.Bucket` with safe defaults
- Add `tests/test_secure_bucket.py` with synthesis verification tests

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
source .venv/bin/activate
pytest tests/test_secure_bucket.py -v
ruff check infiquetra_aws_infra/constructs/secure_bucket.py tests/test_secure_bucket.py
```

Output:
- Tests: 1 passed in ~29s
- Lint: All checks passed!

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `infiquetra_aws_infra/constructs/secure_bucket.py` — `SecureBucket(Construct)` with `__init__(scope, construct_id, *, bucket_name: str | None = None)`, defaults `encryption=BucketEncryption.S3_MANAGED`, `versioned=True`, `block_public_access=BlockPublicAccess.BLOCK_ALL`, `removal_policy=RemovalPolicy.RETAIN`, `.bucket` property returning the underlying `Bucket`
- AC 2 (All named tests pass the verification command): ✓ verified by `pytest tests/test_secure_bucket.py -v` — 1 passed
- AC 3 (No dependencies added unless absolutely required): ✓ no changes to `pyproject.toml`, `requirements.txt`, or lock files — uses existing `aws-cdk-lib` and `constructs` dependencies

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: ✓ only `infiquetra_aws_infra/constructs/secure_bucket.py` and `tests/test_secure_bucket.py` modified
- Do NOT add third-party dependencies unless required by the task body: ✓ no dependencies added
- Do NOT refactor unrelated code in the touched files: ✓ both files are new, no unrelated changes

## Notes

- The `constructs/` subpackage uses Python namespace package semantics (no `__init__.py` required for imports to work in Python 3.13+)
- Optional `bucket_name` validation via `infiquetra_aws_infra.naming.resource_name` is implemented with graceful fallback if that module doesn't exist on the branch

### Coverage

- AC 1: ✓ addressed in `infiquetra_aws_infra/constructs/secure_bucket.py`
- AC 2: ✓ verified by `tests/test_secure_bucket.py` passing
- AC 3: ✓ no dependency changes