### PR TITLE
feat(constructs): Add SecureBucket CDK construct with encryption + versioning

### DIFF
--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from aws_cdk import RemovalPolicy
+from aws_cdk.aws_s3 import BlockPublicAccess, Bucket, BucketEncryption
+from constructs import Construct
+
+
+class SecureBucket(Construct):
+    """A CDK Construct that wraps an S3 Bucket with secure defaults.
+
+    Defaults:
+        encryption: S3_MANAGED (AES-256)
+        versioned: True
+        block_public_access: BLOCK_ALL
+        removal_policy: RETAIN
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        bucket_name: str | None = None,
+    ) -> None:
+        super().__init__(scope, construct_id)
+
+        if bucket_name is not None:
+            _validate_bucket_name(bucket_name)
+
+        self._bucket = Bucket(
+            self,
+            "Bucket",
+            bucket_name=bucket_name,
+            encryption=BucketEncryption.S3_MANAGED,
+            versioned=True,
+            block_public_access=BlockPublicAccess.BLOCK_ALL,
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+
+    @property
+    def bucket(self) -> Bucket:
+        """The underlying S3 Bucket."""
+        return self._bucket
+
+
+def _validate_bucket_name(bucket_name: str) -> None:
+    """Validate a bucket name using the project's naming helper if available.
+
+    If the helper cannot be imported the name is accepted verbatim.
+    If the helper is imported and raises ValueError the exception
+    propagates.
+    """
+    try:
+        from infiquetra_aws_infra.naming import resource_name
+
+        resource_name("s3", "secure", bucket_name, max_len=73)
+    except ImportError:
+        pass
+    except ModuleNotFoundError:
+        pass

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -1,0 +1,86 @@
+from aws_cdk import App, Stack
+from aws_cdk.assertions import Match, Template
+
+from infiquetra_aws_infra.constructs.secure_bucket import SecureBucket
+
+
+def _template_for_bucket(
+    bucket_name: str | None = None,
+) -> tuple[Template, SecureBucket]:
+    """Helper to create a SecureBucket and return its synth template + construct."""
+    app = App()
+    stack = Stack(app, "TestStack")
+    bucket_construct = SecureBucket(
+        stack, "SecureBucket", bucket_name=bucket_name
+    )
+    return Template.from_stack(stack), bucket_construct
+
+
+def test_secure_bucket_applies_secure_defaults() -> None:
+    """Verify the synthesized bucket has all secure defaults applied."""
+    template, _ = _template_for_bucket()
+
+    # Exactly one S3 bucket resource
+    template.resource_count_is("AWS::S3::Bucket", 1)
+
+    # S3-managed encryption (AES-256)
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                    {
+                        "ServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256"
+                        }
+                    }
+                ]
+            }
+        },
+    )
+
+    # Versioning enabled
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {"VersioningConfiguration": {"Status": "Enabled"}},
+    )
+
+    # Block public access — all four booleans set to True
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": True,
+                "BlockPublicPolicy": True,
+                "IgnorePublicAcls": True,
+                "RestrictPublicBuckets": True,
+            }
+        },
+    )
+
+    # Retain deletion policy and update-replace policy
+    template.has_resource(
+        "AWS::S3::Bucket",
+        Match.object_like(
+            {
+                "DeletionPolicy": "Retain",
+                "UpdateReplacePolicy": "Retain",
+            }
+        ),
+    )
+
+
+def test_secure_bucket_exposes_bucket_and_accepts_bucket_name() -> None:
+    """Verify the .bucket property and optional bucket_name pass-through."""
+    template, secure_bucket = _template_for_bucket(
+        bucket_name="my-secure-bucket"
+    )
+
+    # The construct exposes a non-None bucket property
+    assert secure_bucket.bucket is not None
+
+    # The custom bucket name is passed through to the synthesized BucketName
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {"BucketName": "my-secure-bucket"},
+    )


### PR DESCRIPTION
## Linked card

Closes #97

## What changed

- Created `infiquetra_aws_infra/constructs/secure_bucket.py` with `SecureBucket(Construct)` wrapping `aws_cdk.aws_s3.Bucket` with secure defaults (S3_MANAGED encryption, versioning enabled, public access blocked, retain on deletion)
- Added `.bucket` read-only property to expose the underlying `Bucket`
- Added `_validate_bucket_name()` helper that delegates to `naming.resource_name` when available, else accepts bucket names verbatim
- Created `tests/test_secure_bucket.py` with CDK assertion tests

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
.venv/bin/pytest tests/test_secure_bucket.py -v
.venv/bin/pytest
```

```
tests/test_secure_bucket.py ..                                           [100%]
2 passed in 6.80s

8 passed in 6.78s
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `secure_bucket.py` — class signature `__init__(scope, construct_id, *, bucket_name)`, defaults match requirements, validation via `naming.resource_name`, `.bucket` property exposed
- AC 2 (All named tests pass the verification command): ✓ addressed in `test_secure_bucket.py` — both `test_secure_bucket_applies_secure_defaults` and `test_secure_bucket_exposes_bucket_and_accepts_bucket_name` pass
- AC 3 (No dependencies added unless absolutely required): ✓ verified — uses existing `aws-cdk-lib` and `constructs` dependencies; no dependency files modified

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: ✓ not violated
- Do NOT add third-party dependencies unless required by the task body: ✓ not violated
- Do NOT refactor unrelated code in the touched files: ✓ not violated (both files are new)

## Notes

- No `.github/pull_request_template.md` exists in this repo, so the PR body was written from scratch.
- The `ruff` linter issued no warnings after auto-fixing one import-order issue.

### Coverage

- Implementation matches all behaviors described in the task body: ✓ addressed in `infiquetra_aws_infra/constructs/secure_bucket.py`
- All named tests pass the verification command: ✓ addressed in `tests/test_secure_bucket.py`
- No dependencies added unless absolutely required: ✓ no dependency files modified