### PR TITLE
feat(constructs): Add SecureBucket CDK construct with encryption + versioning

### DIFF
--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,0 +1,52 @@
+"""SecureBucket CDK construct with encryption, versioning, and
+public-access blocking."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aws_cdk import RemovalPolicy
+from aws_cdk import aws_s3 as s3
+from constructs import Construct
+
+if TYPE_CHECKING:
+    pass
+
+try:
+    from infiquetra_aws_infra.naming import resource_name as _resource_name
+
+    _NAMING_AVAILABLE = True
+except (ImportError, ModuleNotFoundError):
+    _NAMING_AVAILABLE = False
+
+
+class SecureBucket(Construct):
+    """S3 bucket with secure defaults: encryption, versioning,
+    public-access blocking, and retain deletion policy."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        bucket_name: str | None = None,
+    ) -> None:
+        super().__init__(scope, construct_id)
+
+        if bucket_name is not None and _NAMING_AVAILABLE:
+            _resource_name("s3", "secure", bucket_name, max_len=73)
+
+        self._bucket = s3.Bucket(
+            self,
+            "Bucket",
+            bucket_name=bucket_name,
+            encryption=s3.BucketEncryption.S3_MANAGED,
+            versioned=True,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+
+    @property
+    def bucket(self) -> s3.Bucket:
+        """The underlying S3 bucket resource."""
+        return self._bucket

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -1,0 +1,77 @@
+"""Tests for SecureBucket CDK construct."""
+
+from aws_cdk import App, Stack
+from aws_cdk.assertions import Match, Template
+
+from infiquetra_aws_infra.constructs.secure_bucket import SecureBucket
+
+
+def _template_for_bucket(
+    bucket_name: str | None = None,
+) -> tuple[Template, SecureBucket]:
+    app = App()
+    stack = Stack(app, "TestStack")
+    secure_bucket = SecureBucket(stack, "SecureBucket", bucket_name=bucket_name)
+    template = Template.from_stack(stack)
+    return template, secure_bucket
+
+
+def test_secure_bucket_applies_secure_defaults() -> None:
+    template, _ = _template_for_bucket()
+
+    template.resource_count_is("AWS::S3::Bucket", 1)
+
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                    {
+                        "ServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256",
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "VersioningConfiguration": {"Status": "Enabled"},
+        },
+    )
+
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": True,
+                "BlockPublicPolicy": True,
+                "IgnorePublicAcls": True,
+                "RestrictPublicBuckets": True,
+            },
+        },
+    )
+
+    template.has_resource(
+        "AWS::S3::Bucket",
+        Match.object_like(
+            {
+                "DeletionPolicy": "Retain",
+                "UpdateReplacePolicy": "Retain",
+            },
+        ),
+    )
+
+
+def test_secure_bucket_exposes_bucket_and_accepts_bucket_name() -> None:
+    template, secure_bucket = _template_for_bucket(bucket_name="my-secure-bucket")
+
+    assert secure_bucket.bucket is not None
+
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {"BucketName": "my-secure-bucket"},
+    )


### PR DESCRIPTION
## Linked card

Closes #100

## What changed

- Added `SecureBucket(Construct)` at `infiquetra_aws_infra/constructs/secure_bucket.py` wrapping `aws_cdk.aws_s3.Bucket` with secure defaults: S3-managed encryption, versioning enabled, all public access blocked, and retain deletion policy.
- Added read-only `.bucket` property exposing the underlying `Bucket` resource.
- Added optional `bucket_name` kwarg with validation via `naming.resource_name` when available (falls back to verbatim acceptance).
- Added `tests/test_secure_bucket.py` with CDK assertion tests for all secure defaults and bucket name pass-through.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
pytest tests/test_secure_bucket.py -q
```
Output: `2 passed`

```bash
pytest -q
```
Output: `2 passed`

```bash
ruff check infiquetra_aws_infra/constructs/secure_bucket.py tests/test_secure_bucket.py
```
Output: `All checks passed!`

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ `SecureBucket` class in `infiquetra_aws_infra/constructs/secure_bucket.py` implements all required defaults and `.bucket` property per spec.
- AC 2 (All named tests pass the verification command): ✓ Both `test_secure_bucket_applies_secure_defaults` and `test_secure_bucket_exposes_bucket_and_accepts_bucket_name` pass in `tests/test_secure_bucket.py`.
- AC 3 (No dependencies added unless absolutely required): ✓ No dependency file changes; only `aws-cdk-lib`, `constructs`, and `pytest` (all pre-existing) are used.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `infiquetra_aws_infra/constructs/secure_bucket.py` and `tests/test_secure_bucket.py` created.
- Do NOT add third-party dependencies unless required: not violated — no new deps added.
- Do NOT refactor unrelated code: not violated — both files are new with no adjacent code to refactor.

## Notes

- The `infiquetra_aws_infra.naming` module does not exist on the `main` branch yet (it's on another feature branch). The construct gracefully falls back to accepting `bucket_name` verbatim via an `ImportError`/`ModuleNotFoundError` catch, exactly as specified.
- No `__init__.py` was created for the `constructs` sub-package, per the plan: Python 3 namespace package behavior is sufficient for direct imports.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body (see Notes)): ✓ addressed in `infiquetra_aws_infra/constructs/secure_bucket.py` / `SecureBucket.__init__` + `SecureBucket.bucket`
- AC 2 (All named tests pass the verification command): ✓ addressed in `tests/test_secure_bucket.py` / `test_secure_bucket_applies_secure_defaults` + `test_secure_bucket_exposes_bucket_and_accepts_bucket_name`
- AC 3 (No dependencies added unless absolutely required): ✓ no `pyproject.toml` / `requirements.txt` changes; all imports from pre-existing deps