### PR TITLE
feat(naming): Add resource_name() builder for consistent AWS names

### DIFF
--- a/infiquetra_aws_infra/naming.py
+++ b/infiquetra_aws_infra/naming.py
@@ -1,0 +1,73 @@
+import re
+
+# Allowed characters pattern: only lowercase letters, digits, and hyphens
+_ALLOWED_CHARS_PATTERN = re.compile(r"^[a-z0-9-]+$")
+
+
+def resource_name(service: str, env: str, name: str, max_len: int = 64) -> str:
+    """
+    Generate a standardized resource name for AWS resources.
+
+    Args:
+        service: Service name (e.g., "s3", "lambda")
+        env: Environment name (e.g., "dev", "prod")
+        name: Resource name (e.g., "user-data")
+        max_len: Maximum length of the resulting name (default: 64)
+
+    Returns:
+        Formatted resource name in the format "{service}-{env}-{name}" (lowercased)
+
+    Raises:
+        ValueError: If any component is empty or contains illegal characters
+    """
+    # Validate components are not empty
+    if not service:
+        raise ValueError("service component cannot be empty")
+    if not env:
+        raise ValueError("env component cannot be empty")
+    if not name:
+        raise ValueError("name component cannot be empty")
+
+    # Normalize to lowercase
+    service_lower = service.lower()
+    env_lower = env.lower()
+    name_lower = name.lower()
+
+    # Validate components contain only allowed characters
+    if not _ALLOWED_CHARS_PATTERN.match(service_lower):
+        raise ValueError(
+            f"service '{service}' contains illegal characters "
+            "(only a-z, 0-9, - allowed)"
+        )
+    if not _ALLOWED_CHARS_PATTERN.match(env_lower):
+        raise ValueError(
+            f"env '{env}' contains illegal characters "
+            "(only a-z, 0-9, - allowed)"
+        )
+    if not _ALLOWED_CHARS_PATTERN.match(name_lower):
+        raise ValueError(
+            f"name '{name}' contains illegal characters "
+            "(only a-z, 0-9, - allowed)"
+        )
+
+    # Build the full name
+    prefix = f"{service_lower}-{env_lower}-"
+    full_name = f"{prefix}{name_lower}"
+
+    # If within limit, return as-is
+    if len(full_name) <= max_len:
+        return full_name
+
+    # Truncate name component to fit within max_len
+    available_name_len = max_len - len(prefix)
+
+    # If no room for name, that's an error
+    if available_name_len <= 0:
+        raise ValueError(
+            f"service and env ('{prefix}') exceed max_len={max_len}, "
+            "no room for name component"
+        )
+
+    # Truncate name to fit
+    truncated_name = name_lower[:available_name_len]
+    return f"{prefix}{truncated_name}"

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,64 @@
+import pytest
+
+from infiquetra_aws_infra.naming import resource_name
+
+
+def test_resource_name_happy_path():
+    """Test the basic happy path case."""
+    result = resource_name("s3", "dev", "user-data")
+    assert result == "s3-dev-user-data"
+
+
+def test_resource_name_truncates_name_to_max_len():
+    """Test that the name component is truncated when total length exceeds max_len."""
+    # Create a long name that would make the full name exceed 30 characters
+    long_name = "a" * 100
+    result = resource_name("lambda", "prod", long_name, max_len=30)
+
+    # Should be exactly 30 characters long
+    assert len(result) == 30
+    # Should preserve the prefix
+    assert result.startswith("lambda-prod-")
+    # Should have the truncated name portion
+    expected_name_part = "a" * (30 - len("lambda-prod-"))
+    assert result == f"lambda-prod-{expected_name_part}"
+
+
+def test_resource_name_rejects_empty_component():
+    """Test that empty components raise ValueError."""
+    with pytest.raises(ValueError, match="service component cannot be empty"):
+        resource_name("", "dev", "user-data")
+
+    with pytest.raises(ValueError, match="env component cannot be empty"):
+        resource_name("s3", "", "user-data")
+
+    with pytest.raises(ValueError, match="name component cannot be empty"):
+        resource_name("s3", "dev", "")
+
+
+def test_resource_name_rejects_illegal_chars():
+    """Test that illegal characters raise ValueError."""
+    with pytest.raises(ValueError, match="contains illegal characters"):
+        resource_name("s3", "dev", "Bad Name!")
+
+    with pytest.raises(ValueError, match="contains illegal characters"):
+        resource_name("S3 Service!", "dev", "user-data")
+
+    with pytest.raises(ValueError, match="contains illegal characters"):
+        resource_name("s3", "dev_env", "user-data")
+
+
+def test_resource_name_normalizes_case():
+    """Test that uppercase characters are normalized to lowercase."""
+    result = resource_name("S3", "Dev", "User-Data")
+    assert result == "s3-dev-user-data"
+
+
+def test_resource_name_prefix_exceeds_max_len():
+    """Test the edge case where the prefix exceeds max_len."""
+    with pytest.raises(ValueError, match="no room for name component"):
+        # The prefix "very-long-service-name-development-" is 37 characters
+        # Asking for max_len=30 means there's no room for any name
+        resource_name(
+            "very-long-service-name", "development", "anything", max_len=30
+        )


### PR DESCRIPTION
## Linked card

Closes #106

## What changed

- Added `resource_name(service: str, env: str, name: str, max_len: int = 64) -> str` in `infiquetra_aws_infra/naming.py`
- Added comprehensive tests in `tests/test_naming.py` covering:
  - Happy path: `resource_name("s3", "dev", "user-data")` -> `"s3-dev-user-data"`
  - Length truncation preserving prefix
  - Empty component rejection (ValueError)
  - Illegal character rejection (ValueError)
  - Case normalization (uppercase -> lowercase)
  - Edge case: prefix exceeds max_len (ValueError)

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
source .venv/bin/activate
pytest tests/test_naming.py -v
```

Output: `6 passed in 0.02s`

Linter: `ruff check infiquetra_aws_infra/naming.py tests/test_naming.py` -> `All checks passed!`

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `infiquetra_aws_infra/naming.py` - the `resource_name()` function implements format `{service}-{env}-{name}` lowercased, validates non-empty components with ValueError, validates characters match `^[a-z0-9-]+$` after lowercasing, and truncates name component to fit max_len while preserving the prefix
- AC 2 (All named tests pass the verification command): ✓ addressed in `tests/test_naming.py` - all 6 tests pass: `test_resource_name_happy_path`, `test_resource_name_truncates_name_to_max_len`, `test_resource_name_rejects_empty_component`, `test_resource_name_rejects_illegal_chars`, `test_resource_name_normalizes_case`, `test_resource_name_prefix_exceeds_max_len`
- AC 3 (No dependencies added unless absolutely required): ✓ addressed - uses only Python standard library `re` module; no changes to pyproject.toml, requirements.txt, or uv.lock

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated - only `infiquetra_aws_infra/naming.py` and `tests/test_naming.py` modified
- Do NOT add third-party dependencies: not violated - only standard library used
- Do NOT refactor unrelated code: not violated - only the `resource_name` function and its tests added

## Notes

- Implementation uses standard library `re` module only (no third-party dependencies)
- Error messages include the component name and the invalid value for debugging
- The `test_resource_name_prefix_exceeds_max_len` test covers an additional edge case not explicitly in the requirements but follows logically from the implementation requirements