### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,33 @@
+VALID_ENVIRONMENTS = {"dev", "staging", "prod"}
+
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """Return standardised AWS resource tags.
+
+    Args:
+        env: Deployment environment — must be one of dev, staging, prod.
+        team: Owning team name.
+        project: Project name.
+
+    Returns:
+        A dict with keys Environment, Team, Project, and ManagedBy.
+
+    Raises:
+        ValueError: If *env* is not a recognised environment.
+    """
+    normalized_env = env.strip()
+    normalized_team = team.strip()
+    normalized_project = project.strip()
+
+    if normalized_env not in VALID_ENVIRONMENTS:
+        raise ValueError(
+            f"Invalid environment '{normalized_env}'; "
+            f"expected one of: {', '.join(sorted(VALID_ENVIRONMENTS))}"
+        )
+
+    return {
+        "Environment": normalized_env,
+        "Team": normalized_team,
+        "Project": normalized_project,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,32 @@
+import pytest
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+@pytest.mark.parametrize("env", ["dev", "staging", "prod"])
+def test_common_tags_accepts_valid_environments(env: str) -> None:
+    result = common_tags(env, "platform", "auth")
+    assert result["Environment"] == env
+    assert result["Team"] == "platform"
+    assert result["Project"] == "auth"
+    assert result["ManagedBy"] == "CDK"
+
+
+def test_common_tags_rejects_invalid_environment() -> None:
+    with pytest.raises(ValueError, match="Invalid environment"):
+        common_tags("test", "x", "y")
+
+
+def test_common_tags_strips_whitespace_from_inputs() -> None:
+    result = common_tags("dev  ", " platform ", "auth")
+    assert result == {
+        "Environment": "dev",
+        "Team": "platform",
+        "Project": "auth",
+        "ManagedBy": "CDK",
+    }
+
+
+def test_common_tags_returns_all_required_keys() -> None:
+    result = common_tags("prod", "platform", "billing")
+    assert set(result) == {"Environment", "Team", "Project", "ManagedBy"}


### PR DESCRIPTION
## Linked card

Closes #112

## What changed

- Added `infiquetra_aws_infra/tagging.py` with `common_tags(env, team, project) -> dict[str, str]` function and `VALID_ENVIRONMENTS` constant
- Added `tests/test_tagging.py` with 6 pytest test cases

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
PYTHONPATH=. pytest tests/test_tagging.py -v
# 6 passed in 0.02s
ruff check infiquetra_aws_infra/tagging.py tests/test_tagging.py
# All checks passed!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): `common_tags()` in `tagging.py` normalizes all inputs via `.strip()`, validates env against `{"dev", "staging", "prod"}` raising `ValueError` for invalid values, returns dict with exactly `Environment`, `Team`, `Project`, `ManagedBy` keys where `ManagedBy` is hardcoded to `"CDK"`
- AC 2 (All named tests pass the verification command): 6 tests in `tests/test_tagging.py` — `test_common_tags_accepts_valid_environments` (3 parametrized), `test_common_tags_rejects_invalid_environment`, `test_common_tags_strips_whitespace_from_inputs`, `test_common_tags_returns_all_required_keys` — all pass
- AC 3 (No dependencies added unless absolutely required): Only built-in types used (`str`, `dict`, `set`, `ValueError`); no changes to `pyproject.toml`, `requirements.txt`, or `uv.lock`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: only `infiquetra_aws_infra/tagging.py` and `tests/test_tagging.py` touched — confirmed via `git diff --stat`
- Do NOT add third-party dependencies: no new imports or dependency changes
- Do NOT refactor unrelated code: only new files created, no modifications to existing files

## Notes

- Pre-existing test failure in `test_resource_name_truncates_name_to_max_len` (bug in `naming.py` line 44: `<<` operator instead of `<`) is unrelated and not touched per scope constraints.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `infiquetra_aws_infra/tagging.py`/`common_tags()`
- All named tests pass the verification command: ✓ addressed in `tests/test_tagging.py` (6 test cases)
- No dependencies added unless absolutely required: ✓ no changes to dependency files