### PR TITLE
feat(constructs): add SecureBucket CDK construct

### DIFF
--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -31,9 +31,7 @@ class SecureBucket(Construct):
                 if hasattr(naming, "resource_name") and callable(
                     naming.resource_name
                 ):
-                    named = naming.resource_name(bucket_name)
-                    if isinstance(named, str) and named:
-                        final_bucket_name = named
+                    final_bucket_name = naming.resource_name(bucket_name)
             except ImportError:
                 pass
 

--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from aws_cdk import RemovalPolicy
+from aws_cdk import aws_s3 as s3
+from constructs import Construct
+
+
+class SecureBucket(Construct):
+    """An S3 bucket with secure defaults: SSE-S3 encryption, versioning,
+    public access blocking, and RETAIN deletion policy.
+
+    Optionally accepts a *bucket_name*; if the project provides a
+    ``infiquetra_aws_infra.naming.resource_name()`` helper it will be
+    called automatically.
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        bucket_name: str | None = None,
+    ) -> None:
+        super().__init__(scope, construct_id)
+
+        final_bucket_name = bucket_name
+        if bucket_name is not None:
+            try:
+                from infiquetra_aws_infra import naming  # type: ignore[attr-defined]
+
+                if hasattr(naming, "resource_name") and callable(
+                    naming.resource_name
+                ):
+                    named = naming.resource_name(bucket_name)
+                    if isinstance(named, str) and named:
+                        final_bucket_name = named
+            except ImportError:
+                pass
+
+        self._bucket = s3.Bucket(
+            self,
+            "Bucket",
+            bucket_name=final_bucket_name,
+            encryption=s3.BucketEncryption.S3_MANAGED,
+            versioned=True,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+
+    @property
+    def bucket(self) -> s3.Bucket:
+        """The underlying S3 Bucket resource."""
+        return self._bucket

--- a/infiquetra_aws_infra/constructs/secure_bucket.py
+++ b/infiquetra_aws_infra/constructs/secure_bucket.py
@@ -27,13 +27,13 @@ class SecureBucket(Construct):
         if bucket_name is not None:
             try:
                 from infiquetra_aws_infra import naming  # type: ignore[attr-defined]
-
-                if hasattr(naming, "resource_name") and callable(
-                    naming.resource_name
-                ):
-                    final_bucket_name = naming.resource_name(bucket_name)
             except ImportError:
-                pass
+                naming = None
+
+            if naming is not None and hasattr(naming, "resource_name") and callable(
+                naming.resource_name
+            ):
+                final_bucket_name = naming.resource_name(bucket_name)
 
         self._bucket = s3.Bucket(
             self,

--- a/tests/test_secure_bucket.py
+++ b/tests/test_secure_bucket.py
@@ -1,0 +1,109 @@
+import aws_cdk as cdk
+from aws_cdk.assertions import Template
+
+from infiquetra_aws_infra.constructs.secure_bucket import SecureBucket
+
+
+def test_secure_bucket_sse_s3_encryption() -> None:
+    """SecureBucket must use AES256 (SSE-S3) encryption by default."""
+    app = cdk.App()
+    stack = cdk.Stack(app, "TestStack")
+    SecureBucket(stack, "TestBucket")
+    template = Template.from_stack(stack)
+
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                    {
+                        "ServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256",
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+
+def test_secure_bucket_versioning_enabled() -> None:
+    """SecureBucket must have versioning enabled by default."""
+    app = cdk.App()
+    stack = cdk.Stack(app, "TestStack")
+    SecureBucket(stack, "TestBucket")
+    template = Template.from_stack(stack)
+
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {"VersioningConfiguration": {"Status": "Enabled"}},
+    )
+
+
+def test_secure_bucket_blocks_all_public_access() -> None:
+    """SecureBucket must block all public access."""
+    app = cdk.App()
+    stack = cdk.Stack(app, "TestStack")
+    SecureBucket(stack, "TestBucket")
+    template = Template.from_stack(stack)
+
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": True,
+                "BlockPublicPolicy": True,
+                "IgnorePublicAcls": True,
+                "RestrictPublicBuckets": True,
+            },
+        },
+    )
+
+
+def test_secure_bucket_retain_deletion_policy() -> None:
+    """SecureBucket must use RETAIN for both deletion and update-replace policies."""
+    app = cdk.App()
+    stack = cdk.Stack(app, "TestStack")
+    SecureBucket(stack, "TestBucket")
+    template = Template.from_stack(stack)
+
+    # DeletionPolicy / UpdateReplacePolicy are top-level CFN keys, not
+    # inside Properties, so we match the full resource shape.
+    template.has_resource(
+        "AWS::S3::Bucket",
+        {
+            "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
+        },
+    )
+
+
+def test_secure_bucket_creates_exactly_one_bucket() -> None:
+    """SecureBucket creates exactly one S3 bucket (no extras)."""
+    app = cdk.App()
+    stack = cdk.Stack(app, "TestStack")
+    SecureBucket(stack, "TestBucket")
+    template = Template.from_stack(stack)
+
+    template.resource_count_is("AWS::S3::Bucket", 1)
+
+
+def test_secure_bucket_exposes_bucket_property() -> None:
+    """Exposes the underlying Bucket via the ``.bucket`` property."""
+    app = cdk.App()
+    stack = cdk.Stack(app, "TestStack")
+    sb = SecureBucket(stack, "TestBucket")
+
+    assert sb.bucket is not None
+    assert isinstance(sb.bucket, cdk.aws_s3.Bucket)
+
+
+def test_secure_bucket_with_explicit_name() -> None:
+    """When a bucket_name is provided it must not crash."""
+    app = cdk.App()
+    stack = cdk.Stack(app, "TestStack")
+    SecureBucket(stack, "TestBucket", bucket_name="my-bucket")
+
+    template = Template.from_stack(stack)
+    # The construct should still synth to exactly one bucket
+    template.resource_count_is("AWS::S3::Bucket", 1)


### PR DESCRIPTION
## Summary

Adds a `SecureBucket` CDK Construct with security-first defaults:
- **SSE-S3 encryption** (AES256)
- **Versioning enabled**
- **All public access blocked**
- **RETAIN deletion/update policy**

Optionally accepts a `bucket_name` — if `infiquetra_aws_infra.naming.resource_name()` is available it will be called automatically.

## Validation

- `ruff check` — All checks passed
- `mypy` — Success: no issues found in 2 source files
- `pytest` — 7 passed

Closes #24