### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,36 @@
+"""Standardized resource tagging helper for CDK stacks."""
+
+_ALLOWED_ENVIRONMENTS = {"dev", "staging", "prod"}
+
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """Return a standard set of resource tags.
+
+    Args:
+        env: Deployment environment — must be "dev", "staging", or "prod".
+        team: Owning team name (whitespace trimmed).
+        project: Project name (whitespace trimmed).
+
+    Returns:
+        A dict with Environment, Team, Project, and ManagedBy keys.
+
+    Raises:
+        ValueError: If *env* is not one of the allowed environments.
+    """
+    normalized_env = env.strip()
+    normalized_team = team.strip()
+    normalized_project = project.strip()
+
+    if normalized_env not in _ALLOWED_ENVIRONMENTS:
+        allowed = ", ".join(sorted(_ALLOWED_ENVIRONMENTS))
+        raise ValueError(
+            f"Invalid environment for common tags: "
+            f"expected one of {allowed}; got '{normalized_env}'"
+        )
+
+    return {
+        "Environment": normalized_env,
+        "Team": normalized_team,
+        "Project": normalized_project,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,30 @@
+import pytest
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+@pytest.mark.parametrize("env", ["dev", "staging", "prod"])
+def test_common_tags_accepts_valid_environments(env: str) -> None:
+    result = common_tags(env, "platform", "auth")
+    assert result["Environment"] == env
+    assert result["Team"] == "platform"
+    assert result["Project"] == "auth"
+    assert result["ManagedBy"] == "CDK"
+
+
+def test_common_tags_rejects_invalid_environment() -> None:
+    with pytest.raises(ValueError, match="Invalid environment"):
+        common_tags("test", "x", "y")
+
+
+def test_common_tags_normalizes_whitespace() -> None:
+    result = common_tags("dev  ", " platform ", "auth")
+    assert result["Environment"] == "dev"
+    assert result["Team"] == "platform"
+    assert result["Project"] == "auth"
+    assert result["ManagedBy"] == "CDK"
+
+
+def test_common_tags_returns_all_required_keys() -> None:
+    result = common_tags("prod", "platform", "billing")
+    assert set(result) == {"Environment", "Team", "Project", "ManagedBy"}


### PR DESCRIPTION
## Linked card

Closes #120

## What changed

- `infiquetra_aws_infra/tagging.py` — new module with `common_tags(env, team, project)` function, returns `{"Environment", "Team", "Project", "ManagedBy": "CDK"}` after stripping whitespace and validating env against `{"dev", "staging", "prod"}`
- `tests/test_tagging.py` — new pytest file with 4 test functions: valid envs (parametrized dev/staging/prod), ValueError on invalid env, whitespace normalization, all required keys present

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-aws-infra
uv run pytest tests/test_tagging.py -v
```

Output: 6 passed in 0.04s. ruff check: All checks passed. Coverage on `infiquetra_aws_infra.tagging`: 9/9 statements (100%).

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — ✓ addressed in `infiquetra_aws_infra/tagging.py:common_tags()`. Strips all inputs, validates env, raises ValueError with context, returns exact key set with ManagedBy=CDK.
- AC 2: All named tests pass the verification command — ✓ addressed in `tests/test_tagging.py`. Tests: `test_common_tags_accepts_valid_environments` (parametrized), `test_common_tags_rejects_invalid_environment`, `test_common_tags_normalizes_whitespace`, `test_common_tags_returns_all_required_keys`. All 6 pass.
- AC 3: No dependencies added unless absolutely required — ✓ confirmed. Uses only Python stdlib + existing pytest dev-dep. No pyproject.toml or uv.lock modifications.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set — not violated: only `infiquetra_aws_infra/tagging.py` and `tests/test_tagging.py` created
- Do NOT add third-party dependencies — not violated: no dependency files modified
- Do NOT refactor unrelated code — not violated: both files are new, no existing code touched

## Notes

- Self-critique failed (timed out after 60s — `hermes chat --skill code-review` sub-session drifted to wrong repo). Tagged commit body accordingly.
- Coverage could only be verified after temporarily installing `pytest-cov`; the dependency was reverted before commit so no lockfile churn.

### Coverage

- AC 1 (verbatim): ✓ addressed in `infiquetra_aws_infra/tagging.py:common_tags()`
- AC 2 (verbatim): ✓ addressed in `tests/test_tagging.py` (all 4 named tests pass)
- AC 3 (verbatim): ✓ addressed — no dependency files modified