### PR TITLE
feat(tags): Add common_tags() helper for standardized resource tagging

### DIFF
--- a/infiquetra_aws_infra/tagging.py
+++ b/infiquetra_aws_infra/tagging.py
@@ -1,0 +1,35 @@
+"""Helpers for standardized AWS resource tags."""
+
+_VALID_ENVIRONMENTS = {"dev", "staging", "prod"}
+
+
+def common_tags(env: str, team: str, project: str) -> dict[str, str]:
+    """Return standardized AWS resource tags.
+
+    Args:
+        env: Deployment environment — must be one of dev, staging, prod.
+        team: Owning team name.
+        project: Project name.
+
+    Returns:
+        Dict with Environment, Team, Project, and ManagedBy keys.
+
+    Raises:
+        ValueError: If env is not a recognized environment.
+    """
+    normalized_env = env.strip()
+    normalized_team = team.strip()
+    normalized_project = project.strip()
+
+    if normalized_env not in _VALID_ENVIRONMENTS:
+        raise ValueError(
+            f"Invalid environment '{normalized_env}': "
+            f"expected one of {', '.join(sorted(_VALID_ENVIRONMENTS))}"
+        )
+
+    return {
+        "Environment": normalized_env,
+        "Team": normalized_team,
+        "Project": normalized_project,
+        "ManagedBy": "CDK",
+    }

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,29 @@
+"""Tests for infiquetra_aws_infra.tagging."""
+
+import pytest
+
+from infiquetra_aws_infra.tagging import common_tags
+
+
+@pytest.mark.parametrize("env", ["dev", "staging", "prod"])
+def test_common_tags_accepts_valid_environments(env: str) -> None:
+    tags = common_tags(env, "platform", "auth")
+    assert tags["Environment"] == env
+    assert tags["ManagedBy"] == "CDK"
+
+
+def test_common_tags_rejects_invalid_environment() -> None:
+    with pytest.raises(ValueError, match="Invalid environment"):
+        common_tags("test", "x", "y")
+
+
+def test_common_tags_strips_input_whitespace() -> None:
+    tags = common_tags("dev  ", " platform ", "auth")
+    assert tags["Environment"] == "dev"
+    assert tags["Team"] == "platform"
+    assert tags["Project"] == "auth"
+
+
+def test_common_tags_returns_all_expected_keys() -> None:
+    tags = common_tags("dev", "platform", "auth")
+    assert set(tags) == {"Environment", "Team", "Project", "ManagedBy"}


### PR DESCRIPTION
## Linked card

Closes #122

## What changed

- Add `infiquetra_aws_infra/tagging.py` with `common_tags(env, team, project)` function
- Add `tests/test_tagging.py` with 6 pytest test cases

## How verified

```bash
$ pytest tests/test_tagging.py -v
collected 6 items
tests/test_tagging.py ......                                             [100%]
6 passed in 0.02s

$ pytest --cov=infiquetra_aws_infra.tagging --cov-report=term-missing tests/test_tagging.py
Name                              Stmts   Miss  Cover   Missing
---------------------------------------------------------------
infiquetra_aws_infra/tagging.py       8      0   100%
---------------------------------------------------------------
TOTAL                                 8      0   100%
6 passed in 0.06s

$ ruff check infiquetra_aws_infra/tagging.py tests/test_tagging.py
All checks passed!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): `common_tags()` in `infiquetra_aws_infra/tagging.py` strips all inputs, validates env against {dev, staging, prod}, raises ValueError with context on invalid env, returns dict with Environment/Team/Project/ManagedBy keys (ManagedBy="CDK")
- AC 2 (All named tests pass verification command): 6/6 tests pass in `tests/test_tagging.py` — valid envs parametrized, ValueError for bad env, whitespace stripping, and key-set verification
- AC 3 (No dependencies added): Pure stdlib Python, no pyproject.toml or lockfile changes

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: confirmed — only `tagging.py` and `test_tagging.py` in diff
- Do NOT add third-party dependencies: confirmed — no new imports or dependency changes
- Do NOT refactor unrelated code: confirmed — both files are net-new

## Notes

No deviations from plan. The `.venv/` directory was created on the VM for test execution but is gitignored and not in the diff.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `infiquetra_aws_infra/tagging.py` / `common_tags()`
- All named tests pass the verification command: ✓ addressed in `tests/test_tagging.py` (6 tests, 100% line coverage)
- No dependencies added unless absolutely required: ✓ confirmed — no dependency manifest changes