### PR TITLE
chore(campps): register Option B deploy roles + CodeArtifact profiles

### DIFF
--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -21,6 +21,9 @@ GITHUB_OIDC_URL = "https://token.actions.githubusercontent.com"
 GITHUB_OIDC_HOST = "token.actions.githubusercontent.com"
 GITHUB_OIDC_AUDIENCE = "sts.amazonaws.com"
 
+CODEARTIFACT_DOMAIN = "infiquetra"
+CODEARTIFACT_REPOSITORY = "campps"
+
 
 class CamppsDeployRolesStack(Stack):
     """Create per-service GitHub Actions deploy roles in a CAMPPS account."""
@@ -56,7 +59,7 @@ class CamppsDeployRolesStack(Stack):
                 service_repository=service_repository,
                 target_environment=target_environment,
             )
-            deploy_policies = self._create_serverless_api_deploy_policies(
+            deploy_policies = self._create_deploy_policies(
                 service_repository=service_repository,
                 target_environment=target_environment,
                 permissions_boundary=permissions_boundary,
@@ -238,6 +241,524 @@ class CamppsDeployRolesStack(Stack):
             ],
         )
 
+    def _create_deploy_policies(
+        self,
+        *,
+        service_repository: ServiceRepository,
+        target_environment: DeployEnvironment,
+        permissions_boundary: iam.ManagedPolicy,
+    ) -> tuple[iam.ManagedPolicy, ...]:
+        """Select the deploy policy builder for the service deploy profile.
+
+        ``serverless-api`` returns a split set of managed policies to stay under
+        the IAM managed-policy size limit. The ``platform-foundation`` and
+        ``codeartifact-publish`` profiles each return a single managed policy.
+        """
+        if service_repository.deploy_profile == "platform-foundation":
+            return (
+                self._create_platform_foundation_deploy_policy(
+                    service_repository=service_repository,
+                    target_environment=target_environment,
+                    permissions_boundary=permissions_boundary,
+                ),
+            )
+        if service_repository.deploy_profile == "codeartifact-publish":
+            return (
+                self._create_codeartifact_publish_deploy_policy(
+                    service_repository=service_repository,
+                    target_environment=target_environment,
+                    permissions_boundary=permissions_boundary,
+                ),
+            )
+        return self._create_serverless_api_deploy_policies(
+            service_repository=service_repository,
+            target_environment=target_environment,
+            permissions_boundary=permissions_boundary,
+        )
+
+    def _codeartifact_domain_arn(self) -> str:
+        return str(
+            self.format_arn(
+                service="codeartifact",
+                resource="domain",
+                resource_name=CODEARTIFACT_DOMAIN,
+                arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+            )
+        )
+
+    def _codeartifact_repository_arn(self) -> str:
+        return str(
+            self.format_arn(
+                service="codeartifact",
+                resource="repository",
+                resource_name=f"{CODEARTIFACT_DOMAIN}/{CODEARTIFACT_REPOSITORY}",
+                arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+            )
+        )
+
+    def _codeartifact_package_arn(self) -> str:
+        return str(
+            self.format_arn(
+                service="codeartifact",
+                resource="package",
+                resource_name=f"{CODEARTIFACT_DOMAIN}/{CODEARTIFACT_REPOSITORY}/*",
+                arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+            )
+        )
+
+    def _codeartifact_consume_statements(self) -> list[iam.PolicyStatement]:
+        """Read grant so CI ``uv sync`` can pull the pinned campps-contracts dep."""
+        return [
+            iam.PolicyStatement(
+                sid="CodeArtifactConsumeAuth",
+                actions=[
+                    "codeartifact:GetAuthorizationToken",
+                    "codeartifact:GetRepositoryEndpoint",
+                ],
+                resources=[
+                    self._codeartifact_domain_arn(),
+                    self._codeartifact_repository_arn(),
+                ],
+            ),
+            iam.PolicyStatement(
+                sid="CodeArtifactConsumeRead",
+                actions=["codeartifact:ReadFromRepository"],
+                resources=[self._codeartifact_repository_arn()],
+            ),
+            iam.PolicyStatement(
+                sid="CodeArtifactBearerToken",
+                actions=["sts:GetServiceBearerToken"],
+                resources=["*"],
+            ),
+        ]
+
+    def _cloudformation_baseline_statements(
+        self,
+        *,
+        prefix: str,
+    ) -> list[iam.PolicyStatement]:
+        """CloudFormation + CDK-assets S3 + cdk-bootstrap SSM read baseline."""
+        return [
+            iam.PolicyStatement(
+                sid="CloudFormationDeployments",
+                actions=[
+                    "cloudformation:CancelUpdateStack",
+                    "cloudformation:ContinueUpdateRollback",
+                    "cloudformation:CreateChangeSet",
+                    "cloudformation:CreateStack",
+                    "cloudformation:DeleteChangeSet",
+                    "cloudformation:DeleteStack",
+                    "cloudformation:DescribeChangeSet",
+                    "cloudformation:DescribeStackEvents",
+                    "cloudformation:DescribeStackResource",
+                    "cloudformation:DescribeStackResources",
+                    "cloudformation:DescribeStacks",
+                    "cloudformation:ExecuteChangeSet",
+                    "cloudformation:GetTemplate",
+                    "cloudformation:GetTemplateSummary",
+                    "cloudformation:SetStackPolicy",
+                    "cloudformation:UpdateStack",
+                ],
+                resources=[
+                    self.format_arn(
+                        service="cloudformation",
+                        resource="stack",
+                        resource_name=f"{prefix}-*/*",
+                        arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                    ),
+                    self.format_arn(
+                        service="cloudformation",
+                        resource="changeSet",
+                        resource_name="cdk-deploy-change-set/*",
+                        arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                    ),
+                ],
+            ),
+            iam.PolicyStatement(
+                sid="CloudFormationTemplateValidation",
+                actions=["cloudformation:ValidateTemplate"],
+                resources=["*"],
+            ),
+            iam.PolicyStatement(
+                sid="CdkAssetsBucket",
+                actions=[
+                    "s3:AbortMultipartUpload",
+                    "s3:GetBucketLocation",
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:ListBucketMultipartUploads",
+                    "s3:PutObject",
+                ],
+                resources=[
+                    f"arn:aws:s3:::cdk-hnb659fds-assets-{self.account}-{self.region}",
+                    f"arn:aws:s3:::cdk-hnb659fds-assets-{self.account}-{self.region}/*",
+                ],
+            ),
+            iam.PolicyStatement(
+                sid="CdkBootstrapVersion",
+                actions=["ssm:GetParameter"],
+                resources=[
+                    self.format_arn(
+                        service="ssm",
+                        resource="parameter",
+                        resource_name="cdk-bootstrap/hnb659fds/version",
+                        arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                    )
+                ],
+            ),
+        ]
+
+    def _create_codeartifact_publish_deploy_policy(
+        self,
+        *,
+        service_repository: ServiceRepository,
+        target_environment: DeployEnvironment,
+        permissions_boundary: iam.ManagedPolicy,
+    ) -> iam.ManagedPolicy:
+        prefix = f"campps-{service_repository.name}-{target_environment}"
+        return iam.ManagedPolicy(
+            self,
+            f"{self._logical_id_prefix(service_repository.name)}DeployPolicy",
+            managed_policy_name=service_repository.policy_name(target_environment),
+            description=(
+                f"CodeArtifact publish deployment permissions for "
+                f"{service_repository.repository} {target_environment}"
+            ),
+            statements=[
+                *self._cloudformation_baseline_statements(prefix=prefix),
+                *self._codeartifact_consume_statements(),
+                iam.PolicyStatement(
+                    sid="CodeArtifactPublishAuth",
+                    actions=[
+                        "codeartifact:GetAuthorizationToken",
+                        "sts:GetServiceBearerToken",
+                    ],
+                    resources=["*"],
+                ),
+                iam.PolicyStatement(
+                    sid="CodeArtifactPublishPackages",
+                    actions=["codeartifact:PublishPackageVersion"],
+                    resources=[self._codeartifact_package_arn()],
+                ),
+                iam.PolicyStatement(
+                    sid="CodeArtifactPublishReads",
+                    actions=[
+                        "codeartifact:DescribeDomain",
+                        "codeartifact:DescribePackageVersion",
+                        "codeartifact:DescribeRepository",
+                        "codeartifact:ListPackageVersions",
+                        "codeartifact:ListPackages",
+                        "codeartifact:ListRepositories",
+                        "codeartifact:ReadFromRepository",
+                    ],
+                    resources=[
+                        self._codeartifact_domain_arn(),
+                        self._codeartifact_repository_arn(),
+                        self._codeartifact_package_arn(),
+                    ],
+                ),
+            ],
+        )
+
+    def _create_platform_foundation_deploy_policy(
+        self,
+        *,
+        service_repository: ServiceRepository,
+        target_environment: DeployEnvironment,
+        permissions_boundary: iam.ManagedPolicy,
+    ) -> iam.ManagedPolicy:
+        prefix = f"campps-{service_repository.name}-{target_environment}"
+        scoped_path = f"campps/{service_repository.name}/{target_environment}"
+        permissions_boundary_arn = permissions_boundary.managed_policy_arn
+        return iam.ManagedPolicy(
+            self,
+            f"{self._logical_id_prefix(service_repository.name)}DeployPolicy",
+            managed_policy_name=service_repository.policy_name(target_environment),
+            description=(
+                f"Platform foundation deployment permissions for "
+                f"{service_repository.repository} {target_environment}"
+            ),
+            statements=[
+                *self._cloudformation_baseline_statements(prefix=prefix),
+                *self._codeartifact_consume_statements(),
+                iam.PolicyStatement(
+                    sid="PlatformEventBuses",
+                    actions=[
+                        "events:CreateEventBus",
+                        "events:DeleteEventBus",
+                        "events:DescribeEventBus",
+                        "events:ListTagsForResource",
+                        "events:TagResource",
+                        "events:UntagResource",
+                    ],
+                    resources=[
+                        self.format_arn(
+                            service="events",
+                            resource="event-bus",
+                            resource_name=f"{prefix}-*",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformKmsKeyCreation",
+                    actions=["kms:CreateKey"],
+                    resources=["*"],
+                    conditions={
+                        "StringEquals": {
+                            "aws:RequestTag/Service": service_repository.name,
+                            "aws:RequestTag/Environment": target_environment,
+                        },
+                        "ForAllValues:StringEquals": {
+                            "aws:TagKeys": ["Service", "Environment"]
+                        },
+                    },
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformKmsAliases",
+                    actions=[
+                        "kms:CreateAlias",
+                        "kms:DeleteAlias",
+                        "kms:UpdateAlias",
+                    ],
+                    resources=[
+                        self.format_arn(
+                            service="kms",
+                            resource="alias",
+                            resource_name=f"{prefix}-*",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformTaggedKmsKeys",
+                    actions=[
+                        "kms:DescribeKey",
+                        "kms:EnableKeyRotation",
+                        "kms:GetKeyPolicy",
+                        "kms:GetKeyRotationStatus",
+                        "kms:ListResourceTags",
+                        "kms:PutKeyPolicy",
+                        "kms:ScheduleKeyDeletion",
+                        "kms:TagResource",
+                        "kms:UntagResource",
+                    ],
+                    resources=[
+                        self.format_arn(
+                            service="kms",
+                            resource="key",
+                            resource_name="*",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                    conditions={
+                        "StringEquals": {
+                            "aws:ResourceTag/Service": service_repository.name,
+                            "aws:ResourceTag/Environment": target_environment,
+                        }
+                    },
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformSsmParameters",
+                    actions=[
+                        "ssm:AddTagsToResource",
+                        "ssm:DeleteParameter",
+                        "ssm:GetParameter",
+                        "ssm:GetParameters",
+                        "ssm:ListTagsForResource",
+                        "ssm:PutParameter",
+                        "ssm:RemoveTagsFromResource",
+                    ],
+                    resources=[
+                        self.format_arn(
+                            service="ssm",
+                            resource="parameter",
+                            resource_name=f"{scoped_path}/*",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformSsmParameterDiscovery",
+                    actions=["ssm:DescribeParameters"],
+                    resources=["*"],
+                    conditions={"StringLike": {"ssm:Name": f"/{scoped_path}/*"}},
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformCreateBoundedRoles",
+                    actions=["iam:CreateRole"],
+                    resources=[
+                        self.format_arn(
+                            service="iam",
+                            region="",
+                            resource="role",
+                            resource_name=f"{prefix}-*",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                    conditions={
+                        "StringEquals": {
+                            "iam:PermissionsBoundary": permissions_boundary_arn
+                        }
+                    },
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformManageRoles",
+                    actions=[
+                        "iam:DeleteRole",
+                        "iam:DeleteRolePolicy",
+                        "iam:DetachRolePolicy",
+                        "iam:GetRole",
+                        "iam:GetRolePolicy",
+                        "iam:ListAttachedRolePolicies",
+                        "iam:ListRolePolicies",
+                        "iam:PutRolePolicy",
+                        "iam:TagRole",
+                        "iam:UntagRole",
+                        "iam:UpdateAssumeRolePolicy",
+                        "iam:UpdateRole",
+                    ],
+                    resources=[
+                        self.format_arn(
+                            service="iam",
+                            region="",
+                            resource="role",
+                            resource_name=f"{prefix}-*",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformManagePolicies",
+                    actions=[
+                        "iam:CreatePolicy",
+                        "iam:CreatePolicyVersion",
+                        "iam:DeletePolicy",
+                        "iam:DeletePolicyVersion",
+                        "iam:GetPolicy",
+                        "iam:GetPolicyVersion",
+                        "iam:ListPolicyVersions",
+                        "iam:SetDefaultPolicyVersion",
+                        "iam:TagPolicy",
+                        "iam:UntagPolicy",
+                    ],
+                    resources=[
+                        self.format_arn(
+                            service="iam",
+                            region="",
+                            resource="policy",
+                            resource_name=f"{prefix}-*",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformAttachPolicies",
+                    actions=["iam:AttachRolePolicy"],
+                    resources=[
+                        self.format_arn(
+                            service="iam",
+                            region="",
+                            resource="role",
+                            resource_name=f"{prefix}-*",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                    conditions={
+                        "ArnLike": {
+                            "iam:PolicyARN": self.format_arn(
+                                service="iam",
+                                region="",
+                                resource="policy",
+                                resource_name=f"{prefix}-*",
+                                arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                            )
+                        }
+                    },
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformCloudWatchDashboards",
+                    actions=[
+                        "cloudwatch:DeleteDashboards",
+                        "cloudwatch:GetDashboard",
+                        "cloudwatch:PutDashboard",
+                    ],
+                    resources=[
+                        self.format_arn(
+                            service="cloudwatch",
+                            region="",
+                            resource="dashboard",
+                            resource_name=f"{prefix}-*",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformCloudWatchAlarms",
+                    actions=[
+                        "cloudwatch:DeleteAlarms",
+                        "cloudwatch:DescribeAlarms",
+                        "cloudwatch:PutMetricAlarm",
+                    ],
+                    resources=[
+                        self.format_arn(
+                            service="cloudwatch",
+                            resource="alarm",
+                            resource_name=f"{prefix}-*",
+                            arn_format=ArnFormat.COLON_RESOURCE_NAME,
+                        )
+                    ],
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformLogGroups",
+                    actions=[
+                        "logs:CreateLogGroup",
+                        "logs:DeleteLogGroup",
+                        "logs:DescribeLogGroups",
+                        "logs:ListTagsForResource",
+                        "logs:PutRetentionPolicy",
+                        "logs:TagResource",
+                        "logs:UntagResource",
+                    ],
+                    resources=[
+                        self.format_arn(
+                            service="logs",
+                            resource="log-group",
+                            resource_name=f"/campps/{service_repository.name}/"
+                            f"{target_environment}-*",
+                            arn_format=ArnFormat.COLON_RESOURCE_NAME,
+                        ),
+                        self.format_arn(
+                            service="logs",
+                            resource="log-group",
+                            resource_name=f"/campps/{service_repository.name}/"
+                            f"{target_environment}-*:log-stream:*",
+                            arn_format=ArnFormat.COLON_RESOURCE_NAME,
+                        ),
+                    ],
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformCodeArtifactDomain",
+                    actions=[
+                        "codeartifact:CreateDomain",
+                        "codeartifact:DescribeDomain",
+                        "codeartifact:PutDomainPermissionsPolicy",
+                    ],
+                    resources=[self._codeartifact_domain_arn()],
+                ),
+                iam.PolicyStatement(
+                    sid="PlatformCodeArtifactRepository",
+                    actions=[
+                        "codeartifact:CreateRepository",
+                        "codeartifact:DescribeRepository",
+                        "codeartifact:PutRepositoryPermissionsPolicy",
+                        "codeartifact:ReadFromRepository",
+                    ],
+                    resources=[self._codeartifact_repository_arn()],
+                ),
+            ],
+        )
+
     def _create_serverless_api_deploy_policies(
         self,
         *,
@@ -258,6 +779,7 @@ class CamppsDeployRolesStack(Stack):
                     f"{service_repository.repository} {target_environment}"
                 ),
                 statements=[
+                    *self._codeartifact_consume_statements(),
                     iam.PolicyStatement(
                         sid="CloudFormationDeployments",
                         actions=[

--- a/infiquetra_aws_infra/campps_service_registry.py
+++ b/infiquetra_aws_infra/campps_service_registry.py
@@ -35,6 +35,20 @@ class ServiceRepository:
 CAMPPS_SERVICE_REPOSITORIES: tuple[ServiceRepository, ...] = (
     ServiceRepository(
         name="tenant-setup",
-        repository="infiquetra/campps-tenant-setup-service",
+        repository="infiquetra/campps-tenant-setup",
+    ),
+    ServiceRepository(
+        name="platform",
+        repository="infiquetra/campps-platform",
+        deploy_profile="platform-foundation",
+    ),
+    ServiceRepository(
+        name="contracts",
+        repository="infiquetra/campps-contracts",
+        deploy_profile="codeartifact-publish",
+    ),
+    ServiceRepository(
+        name="identity-access",
+        repository="infiquetra/campps-identity-access",
     ),
 )

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -25,7 +25,7 @@ def synth_template(target_environment: DeployEnvironment = "nonprod") -> Templat
     return synth_template_for_repositories(
         ServiceRepository(
             name="tenant-setup",
-            repository="infiquetra/campps-tenant-setup-service",
+            repository="infiquetra/campps-tenant-setup",
         ),
         target_environment=target_environment,
     )
@@ -83,7 +83,7 @@ def assert_deploy_role_trust(
         string_equals["token.actions.githubusercontent.com:aud"] == "sts.amazonaws.com"
     )
     assert string_equals["token.actions.githubusercontent.com:sub"] == (
-        f"repo:infiquetra/campps-tenant-setup-service:environment:{target_environment}"
+        f"repo:infiquetra/campps-tenant-setup:environment:{target_environment}"
     )
 
     principal = statement["Principal"]
@@ -138,12 +138,25 @@ def managed_policy_document_sizes(template: Template) -> dict[str, int]:
     }
 
 
-def test_default_registry_includes_tenant_setup_service() -> None:
+def test_default_registry_includes_option_b_services() -> None:
     assert (
         ServiceRepository(
             name="tenant-setup",
-            repository="infiquetra/campps-tenant-setup-service",
-            environments=("nonprod", "staging", "production"),
+            repository="infiquetra/campps-tenant-setup",
+        ),
+        ServiceRepository(
+            name="platform",
+            repository="infiquetra/campps-platform",
+            deploy_profile="platform-foundation",
+        ),
+        ServiceRepository(
+            name="contracts",
+            repository="infiquetra/campps-contracts",
+            deploy_profile="codeartifact-publish",
+        ),
+        ServiceRepository(
+            name="identity-access",
+            repository="infiquetra/campps-identity-access",
         ),
     ) == CAMPPS_SERVICE_REPOSITORIES
 
@@ -626,3 +639,111 @@ def test_stack_creates_oidc_provider_for_workload_account() -> None:
             "ClientIdList": ["sts.amazonaws.com"],
         },
     )
+
+
+def collect_actions(template: Template) -> set[str]:
+    actions: set[str] = set()
+    for policy_document in policy_documents(template):
+        for statement in policy_document["Statement"]:
+            for action in normalize_actions(statement.get("Action", [])):
+                actions.add(action)
+    return actions
+
+
+def statements_for_action(template: Template, action_name: str) -> list[dict[str, Any]]:
+    matching: list[dict[str, Any]] = []
+    for policy_document in policy_documents(template):
+        for statement in policy_document["Statement"]:
+            normalized = {
+                action.strip().lower()
+                for action in normalize_actions(statement.get("Action", []))
+            }
+            if action_name in normalized:
+                matching.append(statement)
+    return matching
+
+
+def test_every_campps_profile_includes_codeartifact_consume_grant() -> None:
+    profiles = (
+        ServiceRepository(
+            name="tenant-setup", repository="infiquetra/campps-tenant-setup"
+        ),
+        ServiceRepository(
+            name="platform",
+            repository="infiquetra/campps-platform",
+            deploy_profile="platform-foundation",
+        ),
+        ServiceRepository(
+            name="contracts",
+            repository="infiquetra/campps-contracts",
+            deploy_profile="codeartifact-publish",
+        ),
+    )
+
+    for repository in profiles:
+        template = synth_template_for_repositories(repository)
+        actions = {action.lower() for action in collect_actions(template)}
+        assert "codeartifact:getauthorizationtoken" in actions, repository
+        assert "codeartifact:getrepositoryendpoint" in actions, repository
+        assert "codeartifact:readfromrepository" in actions, repository
+        assert "sts:getservicebearertoken" in actions, repository
+
+
+def test_platform_foundation_role_can_create_scoped_platform_resources() -> None:
+    template = synth_template_for_repositories(
+        ServiceRepository(
+            name="platform",
+            repository="infiquetra/campps-platform",
+            deploy_profile="platform-foundation",
+        )
+    )
+
+    create_role = statements_for_action(template, "iam:createrole")
+    assert create_role
+    assert any(
+        "campps-platform-nonprod-*" in str(statement.get("Resource"))
+        for statement in create_role
+    )
+    assert all(
+        "iam:PermissionsBoundary"
+        in statement.get("Condition", {}).get("StringEquals", {})
+        for statement in create_role
+    )
+
+    create_key = statements_for_action(template, "kms:createkey")
+    assert create_key
+
+    create_domain = statements_for_action(template, "codeartifact:createdomain")
+    assert create_domain
+    assert any(
+        ":domain/infiquetra" in str(statement.get("Resource"))
+        for statement in create_domain
+    )
+
+    create_repo = statements_for_action(template, "codeartifact:createrepository")
+    assert create_repo
+    assert any(
+        ":repository/infiquetra/campps" in str(statement.get("Resource"))
+        for statement in create_repo
+    )
+
+
+def test_codeartifact_publish_role_can_publish_package_versions() -> None:
+    template = synth_template_for_repositories(
+        ServiceRepository(
+            name="contracts",
+            repository="infiquetra/campps-contracts",
+            deploy_profile="codeartifact-publish",
+        )
+    )
+
+    publish = statements_for_action(template, "codeartifact:publishpackageversion")
+    assert publish
+    assert any(
+        ":package/infiquetra/campps/*" in str(statement.get("Resource"))
+        for statement in publish
+    )
+
+    actions = {action.lower() for action in collect_actions(template)}
+    assert "sts:getservicebearertoken" in actions
+    assert "codeartifact:getauthorizationtoken" in actions


### PR DESCRIPTION
## Summary

Provisions GitHub-OIDC deploy roles for the CAMPPS Option B polyrepo and adds the deploy-profile policy builders the new service repos need.

- **Registers three new service deploy roles** in `CAMPPS_SERVICE_REPOSITORIES`:
  - `campps-platform` (`infiquetra/campps-platform`) → `platform-foundation` profile
  - `campps-contracts` (`infiquetra/campps-contracts`) → `codeartifact-publish` profile
  - `campps-identity-access` (`infiquetra/campps-identity-access`) → default `serverless-api` profile
- **Renames** the existing tenant-setup entry repository `infiquetra/campps-tenant-setup-service` → `infiquetra/campps-tenant-setup` to match the `campps-<service>` no-suffix convention. This changes the OIDC trust subject for that role.
- **Adds two new deploy-profile policy builders** selected by `ServiceRepository.deploy_profile`:
  - `platform-foundation`: can create the shared CAMPPS runtime — EventBridge event buses, KMS keys+aliases, SSM parameters under `/campps/platform/<env>/*`, permissions-bounded IAM roles/policies named `campps-platform-<env>-*`, CloudWatch dashboards/alarms/log-groups, and the CodeArtifact domain `infiquetra` + repository `campps` (Create/Describe/Put*Permissions/Read). Resource ARNs are scoped to `campps-platform-<env>-*` / `/campps/platform/<env>/*` where possible, on top of the existing CloudFormation + CDK-assets-S3 + cdk-bootstrap SSM baseline.
  - `codeartifact-publish`: the same CloudFormation/CDK baseline plus `codeartifact:GetAuthorizationToken`, `sts:GetServiceBearerToken`, `codeartifact:PublishPackageVersion`, and `codeartifact:Read*/Describe*/List*` on domain `infiquetra` repo `campps`.
  - The existing `serverless-api` builder remains the default.
- **Adds the CodeArtifact consume grant to every CAMPPS deploy profile** (including `serverless-api`) so CI `uv sync` can resolve the pinned `campps-contracts` dependency: `codeartifact:GetAuthorizationToken` + `codeartifact:GetRepositoryEndpoint` + `codeartifact:ReadFromRepository` (domain `infiquetra` / repo `campps`) + `sts:GetServiceBearerToken` (resource `*`).

## Tests

- Updated `tests/unit/test_campps_deploy_roles_stack.py`: tenant-setup repo rename propagated through the trust-subject and default-registry assertions; new coverage for the CodeArtifact consume grant across all profiles, `platform-foundation` scoped IAM/KMS/CodeArtifact-domain creation, and `codeartifact-publish` `PublishPackageVersion`.
- `uv run pytest -q` — all tests pass
- `uv run ruff check .` — clean
- `uv run mypy .` — clean
- pre-commit (ruff, ruff-format, mypy, bandit) — all pass

## Note on staging

Does **NOT** add the `staging` `DeployEnvironment` literal — that is the operator's separate in-progress change. This PR is additive and works with the current `nonprod`/`production` literal.

## Accounts

campps-dev nonprod=`477152411873`, campps-prod production=`431643435299`.