### PR TITLE
fix(campps): split platform-foundation deploy policy under IAM 6144 limit

### DIFF
--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -250,17 +250,15 @@ class CamppsDeployRolesStack(Stack):
     ) -> tuple[iam.ManagedPolicy, ...]:
         """Select the deploy policy builder for the service deploy profile.
 
-        ``serverless-api`` returns a split set of managed policies to stay under
-        the IAM managed-policy size limit. The ``platform-foundation`` and
-        ``codeartifact-publish`` profiles each return a single managed policy.
+        ``serverless-api`` and ``platform-foundation`` each return a split set
+        of managed policies to stay under the IAM managed-policy size limit.
+        The ``codeartifact-publish`` profile returns a single managed policy.
         """
         if service_repository.deploy_profile == "platform-foundation":
-            return (
-                self._create_platform_foundation_deploy_policy(
-                    service_repository=service_repository,
-                    target_environment=target_environment,
-                    permissions_boundary=permissions_boundary,
-                ),
+            return self._create_platform_foundation_deploy_policies(
+                service_repository=service_repository,
+                target_environment=target_environment,
+                permissions_boundary=permissions_boundary,
             )
         if service_repository.deploy_profile == "codeartifact-publish":
             return (
@@ -460,27 +458,51 @@ class CamppsDeployRolesStack(Stack):
             ],
         )
 
-    def _create_platform_foundation_deploy_policy(
+    def _create_platform_foundation_deploy_policies(
         self,
         *,
         service_repository: ServiceRepository,
         target_environment: DeployEnvironment,
         permissions_boundary: iam.ManagedPolicy,
-    ) -> iam.ManagedPolicy:
+    ) -> tuple[iam.ManagedPolicy, ...]:
+        """Split platform-foundation grants across core/runtime/data policies.
+
+        The combined platform-foundation document exceeds IAM's 6144-byte
+        managed-policy size quota, so the identical set of permissions is
+        partitioned into three managed policies, mirroring the
+        ``serverless-api`` core/runtime/data split:
+
+        * core: CloudFormation + CDK assets + CodeArtifact consume baseline
+        * runtime: EventBridge bus + KMS keys/aliases + SSM platform params
+        * data: IAM (bounded roles/policies) + CloudWatch + log groups +
+          CodeArtifact domain/repository creation
+        """
         prefix = f"campps-{service_repository.name}-{target_environment}"
         scoped_path = f"campps/{service_repository.name}/{target_environment}"
         permissions_boundary_arn = permissions_boundary.managed_policy_arn
-        return iam.ManagedPolicy(
+        logical_prefix = self._logical_id_prefix(service_repository.name)
+        core_policy = iam.ManagedPolicy(
             self,
-            f"{self._logical_id_prefix(service_repository.name)}DeployPolicy",
+            f"{logical_prefix}DeployPolicy",
             managed_policy_name=service_repository.policy_name(target_environment),
             description=(
-                f"Platform foundation deployment permissions for "
+                f"Platform foundation core deployment permissions for "
                 f"{service_repository.repository} {target_environment}"
             ),
             statements=[
                 *self._cloudformation_baseline_statements(prefix=prefix),
                 *self._codeartifact_consume_statements(),
+            ],
+        )
+        runtime_policy = iam.ManagedPolicy(
+            self,
+            f"{logical_prefix}RuntimeDeployPolicy",
+            managed_policy_name=f"{prefix}-gha-runtime-policy",
+            description=(
+                f"Platform foundation runtime deployment permissions for "
+                f"{service_repository.repository} {target_environment}"
+            ),
+            statements=[
                 iam.PolicyStatement(
                     sid="PlatformEventBuses",
                     actions=[
@@ -584,6 +606,18 @@ class CamppsDeployRolesStack(Stack):
                     resources=["*"],
                     conditions={"StringLike": {"ssm:Name": f"/{scoped_path}/*"}},
                 ),
+            ],
+        )
+        data_policy = iam.ManagedPolicy(
+            self,
+            f"{logical_prefix}DataDeployPolicy",
+            managed_policy_name=f"{prefix}-gha-data-policy",
+            description=(
+                f"Platform foundation data and configuration deployment "
+                f"permissions for {service_repository.repository} "
+                f"{target_environment}"
+            ),
+            statements=[
                 iam.PolicyStatement(
                     sid="PlatformCreateBoundedRoles",
                     actions=["iam:CreateRole"],
@@ -758,6 +792,7 @@ class CamppsDeployRolesStack(Stack):
                 ),
             ],
         )
+        return (core_policy, runtime_policy, data_policy)
 
     def _create_serverless_api_deploy_policies(
         self,

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -170,20 +170,44 @@ def test_deploy_role_uses_service_and_environment_name() -> None:
     )
 
 
+PROFILE_REPRESENTATIVE_REPOSITORIES: tuple[ServiceRepository, ...] = (
+    ServiceRepository(
+        name="tenant-setup",
+        repository="infiquetra/campps-tenant-setup",
+    ),
+    ServiceRepository(
+        name="platform",
+        repository="infiquetra/campps-platform",
+        deploy_profile="platform-foundation",
+    ),
+    ServiceRepository(
+        name="contracts",
+        repository="infiquetra/campps-contracts",
+        deploy_profile="codeartifact-publish",
+    ),
+)
+
+IAM_MANAGED_POLICY_SIZE_LIMIT = 6144
+
+
 def test_managed_policy_documents_fit_iam_size_limit() -> None:
     policy_sizes: dict[str, dict[str, int]] = {}
 
-    for environment in DEPLOY_ENVIRONMENTS:
-        template = synth_template(target_environment=environment)
-        policy_sizes[environment] = managed_policy_document_sizes(template)
+    for repository in PROFILE_REPRESENTATIVE_REPOSITORIES:
+        for environment in DEPLOY_ENVIRONMENTS:
+            template = synth_template_for_repositories(
+                repository, target_environment=environment
+            )
+            key = f"{repository.deploy_profile}/{environment}"
+            policy_sizes[key] = managed_policy_document_sizes(template)
 
     violations = {
-        environment: {
+        key: {
             policy_name: size
             for policy_name, size in environment_sizes.items()
-            if size > 6144
+            if size > IAM_MANAGED_POLICY_SIZE_LIMIT
         }
-        for environment, environment_sizes in policy_sizes.items()
+        for key, environment_sizes in policy_sizes.items()
     }
 
     assert not any(violations.values()), violations
@@ -726,6 +750,85 @@ def test_platform_foundation_role_can_create_scoped_platform_resources() -> None
         ":repository/infiquetra/campps" in str(statement.get("Resource"))
         for statement in create_repo
     )
+
+
+def test_platform_foundation_policy_is_split_under_iam_size_limit() -> None:
+    template = synth_template_for_repositories(
+        ServiceRepository(
+            name="platform",
+            repository="infiquetra/campps-platform",
+            deploy_profile="platform-foundation",
+        )
+    )
+
+    sizes = managed_policy_document_sizes(template)
+    deploy_policy_sizes = {
+        name: size
+        for name, size in sizes.items()
+        if name.startswith("campps-platform-nonprod-gha-")
+        and "permissions-boundary" not in name
+    }
+
+    assert set(deploy_policy_sizes) == {
+        "campps-platform-nonprod-gha-deploy-policy",
+        "campps-platform-nonprod-gha-runtime-policy",
+        "campps-platform-nonprod-gha-data-policy",
+    }, deploy_policy_sizes
+    for name, size in deploy_policy_sizes.items():
+        assert size < IAM_MANAGED_POLICY_SIZE_LIMIT, (name, size)
+
+
+def test_platform_foundation_split_preserves_key_abilities() -> None:
+    template = synth_template_for_repositories(
+        ServiceRepository(
+            name="platform",
+            repository="infiquetra/campps-platform",
+            deploy_profile="platform-foundation",
+        )
+    )
+    actions = {action.lower() for action in collect_actions(template)}
+
+    assert "events:createeventbus" in actions
+    assert "kms:createkey" in actions
+    assert "iam:createrole" in actions
+    assert "codeartifact:createdomain" in actions
+    assert "codeartifact:createrepository" in actions
+    assert "cloudwatch:putdashboard" in actions
+    assert "logs:createloggroup" in actions
+
+    ssm_put = statements_for_action(template, "ssm:putparameter")
+    assert ssm_put
+    assert any(
+        "campps/platform/nonprod/*" in str(statement.get("Resource"))
+        for statement in ssm_put
+    )
+
+    create_role = statements_for_action(template, "iam:createrole")
+    assert create_role
+    assert all(
+        "iam:PermissionsBoundary"
+        in statement.get("Condition", {}).get("StringEquals", {})
+        for statement in create_role
+    )
+
+
+def test_codeartifact_publish_policy_fits_iam_size_limit() -> None:
+    template = synth_template_for_repositories(
+        ServiceRepository(
+            name="contracts",
+            repository="infiquetra/campps-contracts",
+            deploy_profile="codeartifact-publish",
+        )
+    )
+
+    sizes = managed_policy_document_sizes(template)
+    deploy_policy_sizes = {
+        name: size for name, size in sizes.items() if "permissions-boundary" not in name
+    }
+
+    assert deploy_policy_sizes
+    for name, size in deploy_policy_sizes.items():
+        assert size < IAM_MANAGED_POLICY_SIZE_LIMIT, (name, size)
 
 
 def test_codeartifact_publish_role_can_publish_package_versions() -> None:


### PR DESCRIPTION
## Problem

Deploying `CamppsNonProdDeployRolesStack` failed: `PlatformDeployPolicy` (the `platform-foundation` deploy profile added in #125) emitted a single managed policy whose rendered document exceeded IAM's hard 6144-byte `PolicySize` quota:

```
Cannot exceed quota for PolicySize: 6144 ... ServiceLimitExceeded
```

The `serverless-api` profile already solved this by splitting into multiple managed policies (core/runtime/data) returned as a tuple from the deploy-profile dispatcher. `platform-foundation` was the only multi-resource profile still returning a single oversized policy.

## Fix

Mirror the serverless-api core/runtime/data split. `_create_platform_foundation_deploy_policies` now returns a tuple of three managed policies; the role attaches each. **Total granted permissions are identical** — statements are only partitioned across policies.

| Policy | Name | Grants |
|---|---|---|
| core | `campps-platform-<env>-gha-deploy-policy` | CloudFormation + CDK assets + CodeArtifact consume baseline |
| runtime | `campps-platform-<env>-gha-runtime-policy` | EventBridge bus + KMS keys/aliases + SSM `/campps/platform/<env>/*` |
| data | `campps-platform-<env>-gha-data-policy` | Bounded IAM roles/policies + CloudWatch dashboards/alarms + log groups + CodeArtifact domain/repo create |

### Per-policy rendered sizes (nonprod)

**platform-foundation** (limit 6144, target <5500):
- `campps-platform-nonprod-gha-deploy-policy`: **2259**
- `campps-platform-nonprod-gha-runtime-policy`: **1860**
- `campps-platform-nonprod-gha-data-policy`: **3168**

**codeartifact-publish** (single policy, verified fine, left as one):
- `campps-contracts-nonprod-gha-deploy-policy`: **3288**

## Tests

- Extended `test_managed_policy_documents_fit_iam_size_limit` to assert **every** managed policy for **every** deploy profile (serverless-api, platform-foundation, codeartifact-publish) across all environments stays < 6144.
- Added `test_platform_foundation_policy_is_split_under_iam_size_limit` (asserts the 3-policy split + each < 6144).
- Added `test_platform_foundation_split_preserves_key_abilities` (EventBridge bus create, KMS key create, IAM `campps-platform-<env>-*` with permissions boundary, SSM `/campps/platform/*`, CodeArtifact domain/repo create, CloudWatch, log groups).
- Added `test_codeartifact_publish_policy_fits_iam_size_limit`.

`ruff check`, `ruff format --check`, `mypy`, full `pytest` (39 passed), and `cdk synth CamppsNonProdDeployRolesStack` all green.