### PR TITLE
fix(campps): grant CDK bootstrap role assume + cfn-exec PassRole

### DIFF
--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -330,6 +330,36 @@ class CamppsDeployRolesStack(Stack):
             ),
         ]
 
+    def _cdk_bootstrap_role_statements(self) -> list[iam.PolicyStatement]:
+        """Allow assuming the CDK modern-bootstrap roles + passing cfn-exec.
+
+        CDK deploys with a restricted GitHub Actions principal by assuming the
+        ``cdk-hnb659fds`` bootstrap deploy/file-publishing/image-publishing/
+        lookup roles, then handing CloudFormation the bootstrap cfn-exec role.
+        Without these grants CDK falls back to acting as the GitHub Actions
+        deploy role directly, which then lacks ``iam:PassRole`` on the
+        bootstrap cfn-exec role and the deploy fails. Scoped to the
+        ``hnb659fds`` qualifier in this account and region only.
+        """
+        return [
+            iam.PolicyStatement(
+                sid="CdkBootstrapAssumeRoles",
+                actions=["sts:AssumeRole"],
+                resources=[
+                    f"arn:aws:iam::{self.account}:role/"
+                    f"cdk-hnb659fds-*-{self.account}-{self.region}",
+                ],
+            ),
+            iam.PolicyStatement(
+                sid="CdkBootstrapPassExecRole",
+                actions=["iam:PassRole"],
+                resources=[
+                    f"arn:aws:iam::{self.account}:role/"
+                    f"cdk-hnb659fds-cfn-exec-role-{self.account}-{self.region}",
+                ],
+            ),
+        ]
+
     def _cloudformation_baseline_statements(
         self,
         *,
@@ -404,6 +434,7 @@ class CamppsDeployRolesStack(Stack):
                     )
                 ],
             ),
+            *self._cdk_bootstrap_role_statements(),
         ]
 
     def _create_codeartifact_publish_deploy_policy(
@@ -870,6 +901,7 @@ class CamppsDeployRolesStack(Stack):
                             f"arn:aws:s3:::cdk-hnb659fds-assets-{self.account}-{self.region}/*",
                         ],
                     ),
+                    *self._cdk_bootstrap_role_statements(),
                     iam.PolicyStatement(
                         sid="CreateBoundedServerlessRoles",
                         actions=["iam:CreateRole"],

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -586,6 +586,8 @@ def test_pass_role_is_scoped_to_serverless_services() -> None:
                 action.strip().lower()
                 for action in normalize_actions(statement.get("Action", []))
             }
+            if statement.get("Sid") == "CdkBootstrapPassExecRole":
+                continue
             if "iam:passrole" in normalized_actions:
                 pass_role_statements.append(statement)
 
@@ -711,6 +713,56 @@ def test_every_campps_profile_includes_codeartifact_consume_grant() -> None:
         assert "codeartifact:getrepositoryendpoint" in actions, repository
         assert "codeartifact:readfromrepository" in actions, repository
         assert "sts:getservicebearertoken" in actions, repository
+
+
+def test_every_campps_profile_can_assume_cdk_bootstrap_roles() -> None:
+    """Every deploy profile must be able to use the CDK modern-bootstrap
+    deploy/file-publishing/image-publishing/lookup roles and pass the
+    bootstrap cfn-exec role, scoped to the hnb659fds qualifier in this
+    account/region only."""
+    expected_assume_resource = (
+        "arn:aws:iam::477152411873:role/cdk-hnb659fds-*-477152411873-us-east-1"
+    )
+    expected_cfn_exec_resource = (
+        "arn:aws:iam::477152411873:role/"
+        "cdk-hnb659fds-cfn-exec-role-477152411873-us-east-1"
+    )
+
+    for repository in PROFILE_REPRESENTATIVE_REPOSITORIES:
+        for environment in DEPLOY_ENVIRONMENTS:
+            template = synth_template_for_repositories(
+                repository, target_environment=environment
+            )
+
+            assume_statements = [
+                statement
+                for policy_document in policy_documents(template)
+                for statement in policy_document["Statement"]
+                if statement.get("Sid") == "CdkBootstrapAssumeRoles"
+            ]
+            assert assume_statements, (repository, environment)
+            for statement in assume_statements:
+                assert set(normalize_actions(statement["Action"])) == {
+                    "sts:AssumeRole"
+                }, statement
+                resources = tuple(normalize_resources(statement["Resource"]))
+                assert expected_assume_resource in resources, statement
+                assert "*" not in resources, statement
+
+            pass_statements = [
+                statement
+                for policy_document in policy_documents(template)
+                for statement in policy_document["Statement"]
+                if statement.get("Sid") == "CdkBootstrapPassExecRole"
+            ]
+            assert pass_statements, (repository, environment)
+            for statement in pass_statements:
+                assert set(normalize_actions(statement["Action"])) == {
+                    "iam:PassRole"
+                }, statement
+                resources = tuple(normalize_resources(statement["Resource"]))
+                assert expected_cfn_exec_resource in resources, statement
+                assert "*" not in resources, statement
 
 
 def test_platform_foundation_role_can_create_scoped_platform_resources() -> None:


### PR DESCRIPTION
## Problem

A real GitHub Actions `cdk deploy` using `campps-platform-nonprod-gha-deploy-role` failed:

- repeated warning: `current credentials could not be used to assume 'arn:aws:iam::477152411873:role/cdk-hnb659fds-deploy-role-477152411873-us-east-1', but are for the right account. Proceeding anyway.`
- fatal: `User: .../campps-platform-nonprod-gha-deploy-role/GitHubActions is not authorized to perform: iam:PassRole on resource: arn:aws:iam::477152411873:role/cdk-hnb659fds-cfn-exec-role-477152411873-us-east-1 because no identity-based policy allows the iam:PassRole action`

## Root Cause (latent gap)

The CAMPPS GHA deploy-role policies in `campps_deploy_roles_stack.py` never granted `sts:AssumeRole` on the `cdk-hnb659fds` modern-bootstrap roles, nor `iam:PassRole` on the bootstrap cfn-exec role. CDK could not assume the bootstrap deploy/file-publishing/lookup roles, so it fell back to acting as the GitHub Actions deploy role directly — which then lacks `iam:PassRole` on the bootstrap cfn-exec-role and the deploy fails.

No CAMPPS service had ever deployed through these roles before, so the gap was latent. It affected **all** deploy profiles: `serverless-api`, `platform-foundation`, and `codeartifact-publish`.

## Fix

Added a shared `_cdk_bootstrap_role_statements()` helper returning two least-privilege statements, scoped to the `hnb659fds` qualifier in this account/region only:

```
Sid: CdkBootstrapAssumeRoles
  Action: sts:AssumeRole
  Resource: arn:aws:iam::<account>:role/cdk-hnb659fds-*-<account>-<region>

Sid: CdkBootstrapPassExecRole
  Action: iam:PassRole
  Resource: arn:aws:iam::<account>:role/cdk-hnb659fds-cfn-exec-role-<account>-<region>
```

Wired into the shared CloudFormation baseline (`_cloudformation_baseline_statements`, used by `codeartifact-publish` and `platform-foundation` core) and into the `serverless-api` core policy, so every profile gets it. The wildcard ARN covers the deploy/file-publishing/image-publishing/lookup bootstrap roles and matches the existing `cdk-hnb659fds-assets-{account}-{region}` ARN-building style in this file.

## IAM size-limit safety

Each affected policy grew by ~331 bytes; all stay well under the 6144-byte IAM managed-policy limit:

| Profile | Policy | Before | After |
|---|---|---|---|
| serverless-api | gha-deploy-policy | 3919 | 4250 |
| platform-foundation | gha-deploy-policy | 2259 | 2590 |
| codeartifact-publish | gha-deploy-policy | 3288 | 3619 |

Largest policy overall is the unchanged serverless-api `gha-runtime-policy` at 4470.

## Tests

- Updated `test_pass_role_is_scoped_to_serverless_services` to exclude the new `CdkBootstrapPassExecRole` sid (it intentionally targets the bootstrap cfn-exec role, not serverless app roles).
- Added `test_every_campps_profile_can_assume_cdk_bootstrap_roles` asserting all three profiles, across all 3 environments, include the scoped AssumeRole + cfn-exec PassRole statements with no `*` resources.
- Size-limit tests remain green.

Validation: `ruff check`, `ruff format --check`, `mypy`, `pytest` all pass; `cdk synth CamppsNonProdDeployRolesStack` succeeds and resolves ARNs correctly for every profile.