### PR TITLE
chore: update context library repo names

### DIFF
--- a/docs/superpowers/specs/2026-05-06-campps-aws-ci-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-06-campps-aws-ci-foundation-design.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-CAMPPS development will start from `../campps-blueprint` and move into multiple deployable repositories. Each service or client repository should own its code, IaC, and isolated data stores. The first deployable work is likely a full vertical app slice driven by blueprint context packs.
+CAMPPS development will start from `../campps-context-library` and move into multiple deployable repositories. Each service or client repository should own its code, IaC, and isolated data stores. The first deployable work is likely a full vertical app slice driven by blueprint context packs.
 
 The AWS organization foundation is already in place: `campps-dev` lives under `Apps/CAMPPS/NonProd`, and `campps-prod` lives under `Apps/CAMPPS/Production`. The remaining risk is access and release flow. Human access still uses direct legacy `AdministratorAccess` assignments, and the current GitHub Actions role in this infrastructure repo has broad management-account permissions and org-wide GitHub trust.
 


### PR DESCRIPTION
## Summary

- Update tracked references from the old blueprint repository names to the renamed context-library repositories.
- Replace GitHub URLs, local path examples, mappings, tests, and docs that used `campps-blueprint` or `mimir-blueprint`.
- Leave generic blueprint terminology intact where it refers to an artifact type rather than the renamed repositories.

## Verification

- `git diff --check`
- `git grep -n -I -e 'campps-blueprint' -e 'mimir-blueprint' -- .` returned no tracked matches
- Repo-specific checks were run where applicable: docs validation, targeted SDLC-manager tests, and Python syntax compilation.
