### PR TITLE
Fix CAMPPS platform SSM path read grant

### DIFF
--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -638,6 +638,18 @@ class CamppsDeployRolesStack(Stack):
                     resources=["*"],
                     conditions={"StringLike": {"ssm:Name": f"/{scoped_path}/*"}},
                 ),
+                iam.PolicyStatement(
+                    sid="PlatformSsmParameterPathRead",
+                    actions=["ssm:GetParametersByPath"],
+                    resources=[
+                        self.format_arn(
+                            service="ssm",
+                            resource="parameter",
+                            resource_name=scoped_path,
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                ),
             ],
         )
         data_policy = iam.ManagedPolicy(

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -872,9 +872,11 @@ def test_platform_foundation_can_read_platform_ssm_namespace_by_path() -> None:
 
     get_by_path = statements_for_action(template, "ssm:getparametersbypath")
     assert get_by_path
+    resources = [str(statement.get("Resource")) for statement in get_by_path]
+    assert any("campps/platform/nonprod" in resource for resource in resources)
+    assert any("campps/platform/nonprod/*" in resource for resource in resources)
     for statement in get_by_path:
         resource = str(statement.get("Resource"))
-        assert "campps/platform/nonprod/*" in resource, statement
         assert "campps/identity-access/nonprod" not in resource, statement
         assert "campps/contracts/nonprod" not in resource, statement
         assert statement.get("Resource") != "*", statement


### PR DESCRIPTION
## Summary
- add the base SSM path ARN required by GetParametersByPath authorization
- keep write/delete SSM permissions scoped to the recursive child parameter namespace
- extend the platform deploy-role unit test to cover both path resources

## Test Plan
- git diff --check
- uv run pytest tests/unit/test_campps_deploy_roles_stack.py -q
- uv run cdk -a "python app_campps_bootstrap.py" synth --quiet

## Evidence
- campps-platform nonprod workflow run 26656797014 still used the fallback because AWS authorized GetParametersByPath against arn:aws:ssm:us-east-1:477152411873:parameter/campps/platform/nonprod, not only arn:aws:ssm:us-east-1:477152411873:parameter/campps/platform/nonprod/*