### PR TITLE
feat(campps): register tenant-setup for deploy role generation

### DIFF
--- a/infiquetra_aws_infra/campps_service_registry.py
+++ b/infiquetra_aws_infra/campps_service_registry.py
@@ -47,4 +47,8 @@ CAMPPS_SERVICE_REPOSITORIES: tuple[ServiceRepository, ...] = (
         name="identity-access",
         repository="infiquetra/campps-identity-access",
     ),
+    ServiceRepository(
+        name="tenant-setup",
+        repository="infiquetra/campps-tenant-setup",
+    ),
 )

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -154,6 +154,10 @@ def test_default_registry_includes_current_service_repositories() -> None:
             name="identity-access",
             repository="infiquetra/campps-identity-access",
         ),
+        ServiceRepository(
+            name="tenant-setup",
+            repository="infiquetra/campps-tenant-setup",
+        ),
     ) == CAMPPS_SERVICE_REPOSITORIES
 
 


### PR DESCRIPTION
Implements C0.1 prerequisite for tenant-setup deploy role in infra registry.

Parent: campps-platform#9.

## Evidence
- Added tenant-setup repository to SERVICE registry.
- Updated deploy-role stack tests for registry expectation.
