### PR TITLE
feat(campps): register all CAMPPS services + add web-app OIDC deploy profile (#134, #135)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ cdk.context.json
 # Claude session state
 .remember/
 .claude/worktrees/
+.claude/saga/
 .superpowers/
 
 # Antigravity session state

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -25,6 +25,37 @@
 
 ---
 
+## 2026-06-20
+
+### C0.3 — register all CAMPPS services + add a `web-app` deploy profile (planned)
+
+**Decision.** Register the 6 missing CAMPPS backend services in `CAMPPS_SERVICE_REPOSITORIES`
+(`coppa-consent`, `registration`, `payments`, `health-forms`, `activities-achievements`,
+`staff-management` — all `serverless-api`, all 3 envs) so the registry-driven deploy-roles stack
+auto-mints their per-service OIDC roles (S4 rides on S3 — no new role code for backends). Add a new,
+dedicated `web-app` deploy profile (static-site: S3 + CloudFront + invalidation + CDK-bootstrap baseline)
+for `campps-web-app` instead of the default serverless-api, and make `_create_deploy_policies()` raise on
+any unrecognized profile. Canonical service set sourced from `campps-context-library`
+phase-1a-build-program.md, not the conflicting "7 vs 10" card text. Deploy to nonprod (`477152411873`)
+only; staging/production deferred to a reviewer-gated `/deploy`.
+
+**Rejected alternatives.**
+- Register `campps-web-app` as `serverless-api` — gives a Flutter Web static client Lambda/DynamoDB/API-GW
+  grants it never uses (overprivileged). Rejected.
+- Fully defer `campps-web-app` — cleaner, but operator chose to include it provisionally now.
+- Keep the silent serverless-api fallback for unknown profiles — a latent footgun; replaced with a guard.
+- Trust the cards' literal "7 service repos" — contradicted by the build program (10 backends + web-app).
+
+**Implementation.** Plan: `docs/plans/2026-06-20-c0-3-aws-infra-service-registry-oidc-plan.md`. Touches
+`infiquetra_aws_infra/campps_service_registry.py`, `infiquetra_aws_infra/campps_deploy_roles_stack.py`,
+`tests/unit/test_campps_deploy_roles_stack.py`.
+
+**Revisit when.** `campps-web-app`'s real CDK stack lands — confirm S3+CloudFront vs Amplify and tighten
+the `web-app` profile's least-privilege scope (the profile is shipped **provisional** because the web-app
+is an empty scaffold today with no settled deploy target).
+
+**Commit.** PR pending (infiquetra-aws-infra#134 + #135; parent campps-platform#10).
+
 ## 2026-05-16
 
 ### Rename the CAMPPS nonprod account nickname from `campps-dev` to `campps-nonprod`

--- a/docs/plans/2026-06-20-c0-3-aws-infra-service-registry-oidc-plan.md
+++ b/docs/plans/2026-06-20-c0-3-aws-infra-service-registry-oidc-plan.md
@@ -1,0 +1,181 @@
+---
+title: C0.3 aws-infra — register CAMPPS services + per-service OIDC deploy roles
+type: feat
+status: active
+date: 2026-06-20
+origin: issue-derived (no in-repo upstream doc) — infiquetra-aws-infra#134 + #135, sub-issues of infiquetra/campps-platform#10; canonical service set from campps-context-library phase-1a-build-program.md
+---
+
+# C0.3 aws-infra — register CAMPPS services + per-service OIDC deploy roles
+
+## Summary
+
+Register the 6 missing CAMPPS backend services in `campps_service_registry` (S3, #134) so the
+deploy-roles stack auto-mints their per-service GitHub OIDC deploy roles (S4, #135), and add a
+dedicated `web-app` deploy profile so `campps-web-app` gets a least-privilege static-site role instead
+of an overprivileged serverless-api one. Deploy the result to the nonprod account.
+
+## Problem Frame
+
+C0.3's campps-platform half (cookiecutter home + ADR-0005 tag-promotion) shipped via PR #22 and nonprod
+is live (`v0.1.0`). The remaining capability work is in this repo: only 4 of the 10 CAMPPS backend
+services are registered, so the other 6 have no OIDC deploy role and cannot deploy without static keys.
+`campps-web-app` is also unregistered and has no correct deploy profile. Until these land, the C0.3
+E2E (campps-platform#17) is blocked.
+
+The deploy-roles machinery already exists and is registry-driven (`campps_deploy_roles_stack.py:49-68`
+iterates `CAMPPS_SERVICE_REPOSITORIES`, minting a role + 3 managed policies + permissions boundary per
+service per environment). So S4 for the 6 backends is **zero new code** — it rides on the S3 registry
+edits. The only genuinely new work is the `web-app` profile.
+
+## Requirements
+
+R1. All 10 CAMPPS deployable backend services are in `CAMPPS_SERVICE_REPOSITORIES` (the 4 existing +
+`coppa-consent`, `registration`, `payments`, `health-forms`, `activities-achievements`,
+`staff-management`), each producing a correctly-scoped per-environment OIDC deploy role.
+
+R2. `campps-web-app` is registered with a dedicated `web-app` deploy profile scoped to static-site
+hosting (S3 + CloudFront + invalidation + the shared CDK-bootstrap baseline) — **not** serverless-api,
+so its role carries no Lambda / DynamoDB / API Gateway / EventBridge grants.
+
+R3. `_create_deploy_policies()` handles `web-app` explicitly and **raises** on any unrecognized
+`deploy_profile` (no silent serverless-api fallback).
+
+R4. Unit tests assert: registry membership equals the full canonical set; every registered service
+mints a deploy role + permissions boundary per declared environment; trust subjects are
+environment-scoped; the `web-app` policy grants only static-site actions and none of the
+serverless-api actions.
+
+R5. The roles stack is deployed to the nonprod account (`477152411873`) and, for each newly registered
+service, the `campps-<name>-nonprod-gha-deploy-role` **exists with the correct env-scoped trust subject**
+(`repo:infiquetra/campps-<name>:environment:nonprod`) — verified via `aws iam get-role` / CloudFormation
+outputs. (The actual end-to-end OIDC *assume* is **not** provable in this slice: the 6 new service repos
+are bare scaffolds with no deploy workflow to mint an OIDC token. That proof is deferred to a service's
+first real deploy / the C0.3 E2E — see Deferred to Follow-Up.)
+
+## Key Technical Decisions
+
+**KTD1 — Source the service set from the build program, not the card text.** The cards conflict
+("7 service repos" in titles, "10 services + web-app" in AC). Grounded truth
+(`campps-context-library` phase-1a-build-program.md): 10 deployable backends (4 registered + 6 new, all
+`serverless-api`, all 3 environments) + `campps-web-app` (frontend). Rejected: trusting the literal
+"7 service repos".
+
+**KTD2 — S4 for the 6 backends is no new code; it rides on S3.** The stack auto-mints scoped roles from
+the registry (`campps_deploy_roles_stack.py:49-68`), so registering the 6 entries satisfies #135 for
+them. Rejected: authoring roles per service by hand.
+
+**KTD3 — web-app gets a new, dedicated `web-app` profile (provisional S3+CloudFront scope).** A Flutter
+Web static client must not hold backend (Lambda/DynamoDB/API-GW/EventBridge) grants. **Provisional**:
+`campps-web-app` is currently an empty scaffold with no CDK stack and no settled deploy target, so the
+profile is scoped to the standard static-site pattern and **must be revisited** when the web-app's real
+stack lands (it may be Amplify or differ). Rejected: register web-app as serverless-api (overprivileged);
+fully defer web-app (operator chose to include provisionally).
+
+**KTD4 — Add an unrecognized-profile guard.** `_create_deploy_policies()` raises `ValueError` for any
+`deploy_profile` outside the known set, preventing a future typo from silently minting an overprivileged
+serverless-api role. Rejected: leave the silent default fallback (the latent bug agent analysis found).
+
+**KTD5 — Destination is nonprod only for now.** Deploy the roles stack to nonprod (`477152411873`) after
+merge; staging (`050922968859`) / production (`431643435299`) role deploys are deferred to a separate,
+reviewer-gated `/deploy`. Rationale: nonprod is the active environment toward the Nov-2026 bar.
+
+**KTD6 — The roles stack is deployed with privileged creds via the bootstrap app, not OIDC.** It is
+applied through the standalone `app_campps_bootstrap.py` CDK app (`CamppsNonProdDeployRolesStack`) using
+an AdministratorAccess profile in the target account — the stack *mints* the per-service OIDC roles, so it
+cannot bootstrap itself with them (chicken-and-egg). Rationale: matches how nonprod was deployed
+2026-05-29. Rejected: gating this stack behind the OIDC roles it creates (impossible).
+
+## Implementation Units
+
+### U1. Register the 6 missing backend services (S3 #134)
+
+Add 6 `ServiceRepository` entries to `CAMPPS_SERVICE_REPOSITORIES` in
+`infiquetra_aws_infra/campps_service_registry.py:35-54` — `coppa-consent`, `registration`, `payments`,
+`health-forms`, `activities-achievements`, `staff-management`, each `infiquetra/campps-<name>`, default
+`serverless-api` profile, default all-3 environments. No stack changes needed; roles auto-mint.
+
+**Test scenario:** registry membership now equals the canonical 10-backend set; a parametrized test
+asserts every `serverless-api` service mints a `campps-<name>-<env>-gha-deploy-role` + permissions
+boundary for each declared environment, with an env-scoped trust subject.
+**Test file:** `tests/unit/test_campps_deploy_roles_stack.py`
+
+### U2. Add the `web-app` deploy profile + register campps-web-app (S4 #135)
+
+Author `_create_web_app_deploy_policy()` in `infiquetra_aws_infra/campps_deploy_roles_stack.py`. Branch on
+`deploy_profile == "web-app"` in `_create_deploy_policies()` (near the existing `:257-275` profile switch).
+Register `campps-web-app` (`infiquetra/campps-web-app`, `deploy_profile="web-app"`, all 3 environments).
+Add a code comment marking the profile **provisional** per KTD3.
+
+**Pinned provisional action set** (least-privilege static-site deploy; revise when the real web-app CDK
+stack lands — KTD3). Mirror the existing profiles' shared baseline, then grant only static-site actions,
+all resource-scoped to the service's `campps-web-app-<env>-*` naming:
+
+- **CloudFormation + CDK bootstrap baseline** — same as the other profiles (assume the CDK
+  `cdk-hnb659fds-*` bootstrap roles; CloudFormation create/update/describe on the service's own stacks).
+- **S3** — `s3:CreateBucket`, `PutBucketPolicy`, `PutBucketWebsite`, `PutEncryptionConfiguration`,
+  `PutObject`, `DeleteObject`, `GetObject`, `ListBucket`, `GetBucket*` on `arn:aws:s3:::campps-web-app-<env>-*`.
+- **CloudFront** — `CreateDistribution*`, `UpdateDistribution`, `GetDistribution*`,
+  `CreateInvalidation`, `Tag/UntagResource`, plus `CreateOriginAccessControl` / `GetOriginAccessControl`
+  (OAC for private-bucket origin).
+- **No** Lambda / DynamoDB / API Gateway / EventBridge / SQS / Secrets Manager grants.
+- **Deferred (custom domain), out of this slice:** ACM (`RequestCertificate` / `DescribeCertificate`) and
+  Route53 record management — add only if/when the web-app adopts a custom domain. KMS only if the bucket
+  later uses a CMK (default SSE-S3 needs none).
+
+**Test scenario:** the web-app role exists per environment; its policy grants the pinned S3 (`s3:PutObject`
+on `campps-web-app-<env>-*`) + CloudFront (`cloudfront:CreateInvalidation`) actions and asserts the
+**absence** of `lambda:*`, `dynamodb:*`, `apigateway:*`, `events:*`, `sqs:*`, `secretsmanager:*`; the role
+trust subject is env-scoped; managed-policy size fits the IAM 6144-byte limit.
+**Test file:** `tests/unit/test_campps_deploy_roles_stack.py`
+
+### U3. Guard unrecognized deploy profiles (KTD4)
+
+In `_create_deploy_policies()`, replace the silent serverless-api default fallback with an explicit
+branch set + `raise ValueError(f"unknown deploy_profile: {profile}")` for anything outside
+`{serverless-api, platform-foundation, codeartifact-publish, web-app}`.
+
+**Test scenario:** constructing the stack with a `ServiceRepository(deploy_profile="bogus")` raises
+`ValueError`.
+**Test file:** `tests/unit/test_campps_deploy_roles_stack.py`
+
+### U4. Deploy to nonprod + verify (destination: nonprod-deploy)
+
+After merge, deploy the nonprod roles stack from the **separate bootstrap CDK app** with **privileged
+credentials**: `cdk deploy CamppsNonProdDeployRolesStack --app "python3 app_campps_bootstrap.py"` against
+the nonprod account (`477152411873`) using an AdministratorAccess profile in `campps-nonprod` (the
+bootstrap stack *creates* the per-service OIDC roles, so it cannot assume them — KTD6; this mirrors the
+2026-05-29 precedent where `CamppsNonProdDeployRolesStack` reached `UPDATE_COMPLETE`). Verify each new
+service's `campps-<name>-nonprod-gha-deploy-role` exists with the env-scoped trust subject (per R5) via
+`aws iam get-role` or the stack's CloudFormation outputs. Executed via `/deploy`/`/qa`, not `/work`. The
+actual OIDC assume is deferred (R5 / Deferred to Follow-Up).
+
+**Test expectation:** none -- ops/deploy verification (synth assertions live in U1-U3; this unit is the
+real nonprod apply + a role-existence/trust check, not an assume probe).
+
+## Scope Boundaries
+
+**Out of scope (true non-goals):**
+- Staging / production role deploys — separate reviewer-gated `/deploy` (KTD5).
+- The web-app's actual Flutter scaffold / CDK stack — owned by the `campps-web-app` build lane.
+- `campps-mvp` (testing), `campps-context-library` (docs) — not deployable services.
+
+**Deferred to Follow-Up Work:**
+- **Revisit the `web-app` profile** when `campps-web-app`'s real CDK stack lands — confirm S3+CloudFront
+  vs Amplify and tighten least-privilege (tracked against R2/KTD3).
+- **Prove the end-to-end OIDC assume** (#135 AC: "a deploy assumes the role with no static creds") — only
+  demonstrable once a registered service repo has a real deploy workflow to mint an OIDC token; happens at
+  that service's first deploy or via the C0.3 E2E. This slice proves role *existence* + correct trust, not
+  the live assume — so #135 closes here for role provisioning, with the assume-proof tracked downstream.
+- **Create `infiquetra/campps-e2e-canary`** (with an assumable OIDC role) — a prerequisite for the C0.3
+  E2E (campps-platform#17), not part of this slice.
+
+## Risk Analysis & Mitigation
+
+**Risk — provisional web-app profile churn.** If campps-web-app ends up on Amplify or a non-S3 target,
+the profile + role need rework. *Mitigation:* scope to least-privilege static-site, mark provisional in
+code + journal, and gate a revisit on the web-app build lane.
+
+**Risk — mis-scoped IAM on nonprod.** A new policy could over/under-grant. *Mitigation:* unit tests
+assert per-profile scoping and the absence of backend actions on web-app; nonprod-only first, staging/prod
+deferred.

--- a/docs/reviews/2026-06-20-c0-3-aws-infra-service-registry-oidc-review.md
+++ b/docs/reviews/2026-06-20-c0-3-aws-infra-service-registry-oidc-review.md
@@ -1,0 +1,40 @@
+---
+title: Doc-review — C0.3 aws-infra service-registry + OIDC roles plan
+type: doc-review
+date: 2026-06-20
+status: not-blocked
+target: docs/plans/2026-06-20-c0-3-aws-infra-service-registry-oidc-plan.md
+reviewed_revision: working tree (uncommitted)
+linked_issues: infiquetra-aws-infra#134, infiquetra-aws-infra#135, infiquetra/campps-platform#10
+---
+
+# Doc-review — C0.3 aws-infra service-registry + OIDC roles plan
+
+## Verdict
+
+**Ready to drive implementation. Not blocked** — no P0/P1 remain after safe fixes. An inline `/work`
+agent can execute U1–U3 confidently; U4 (nonprod deploy) is now grounded in the real bootstrap-app +
+privileged-cred path.
+
+## Applied fixes (safe, evidence-backed, in place)
+
+| # | Fix | Evidence |
+|---|---|---|
+| F1 | **R5 + U4 rewritten** to specify the real deploy path: privileged `cdk deploy CamppsNonProdDeployRolesStack` via `app_campps_bootstrap.py` with AdministratorAccess (the bootstrap stack mints the OIDC roles, so it can't use them). | `app_campps_bootstrap.py:18-40`; QUEUED.md:35 (2026-05-29 nonprod precedent) |
+| F2 | **R5 verification corrected** from "a role-assume is verified" to "role exists with correct env-scoped trust"; the live OIDC assume moved to Deferred (the 6 service repos are bare scaffolds with no deploy workflow to mint a token). | repos are scaffolds (gh: only README/LICENSE/.gitignore) |
+| F3 | **Added KTD6** (privileged bootstrap-app deploy / chicken-and-egg) and a Deferred-to-Follow-Up entry clarifying #135 closes for role *provisioning*, with the assume-proof tracked downstream. | same as F1/F2 |
+
+## Findings — all resolved (operator-requested fix pass, 2026-06-20)
+
+| Priority | Status | Finding / resolution |
+|---|---|---|
+| P2 | **resolved** | **web-app profile action set was not pinned.** Fixed: U2 now pins a concrete provisional least-privilege set — S3 (`campps-web-app-<env>-*`-scoped object/bucket ops), CloudFront (distribution + `CreateInvalidation` + OAC), CDK-bootstrap baseline; **no** Lambda/DynamoDB/API-GW/EventBridge/SQS/Secrets; ACM/Route53 (custom domain) + KMS explicitly deferred. Still marked provisional (revise when the real web-app CDK stack lands). |
+| P3 | **resolved** | **`origin:` not repo-relative.** Fixed: re-labeled `issue-derived (no in-repo upstream doc)` — accurate, since the plan derives from the GitHub issues, not an in-repo brainstorm. |
+| P3 | **resolved (no-op)** | **`tenant-setup` history note.** Confirmed correctly registered; no plan change needed — recorded so `/work` doesn't re-litigate. |
+
+## Residual risk from limited evidence
+
+The `web-app` deploy profile is designed against an *assumed* S3+CloudFront target because
+`campps-web-app` is an empty scaffold. If that assumption is wrong (e.g. Amplify), U2's policy and the
+web-app role need revision — already captured as a Deferred follow-up and a provisional code comment.
+No way to reduce this further without first settling the web-app deploy architecture.

--- a/docs/work-sessions/2026-06-20-c0-3-service-registry-oidc.md
+++ b/docs/work-sessions/2026-06-20-c0-3-service-registry-oidc.md
@@ -1,0 +1,71 @@
+---
+title: Work session — C0.3 aws-infra service registry + per-service OIDC deploy roles
+date: 2026-06-20
+issue: infiquetra-aws-infra#134, infiquetra-aws-infra#135 (sub-issues of campps-platform#10)
+plan: docs/plans/2026-06-20-c0-3-aws-infra-service-registry-oidc-plan.md
+doc_review: docs/reviews/2026-06-20-c0-3-aws-infra-service-registry-oidc-review.md
+branch: worktree-c0-3-service-registry-oidc
+destination: nonprod-deploy
+status: PR-ready (pending review gate)
+---
+
+# Work session — C0.3 service registry + OIDC deploy roles
+
+## What was built (by U-ID)
+
+- **U1 — register the 6 missing backend services (S3, #134).** Added `coppa-consent`,
+  `registration`, `payments`, `health-forms`, `activities-achievements`, `staff-management` to
+  `CAMPPS_SERVICE_REPOSITORIES` (`infiquetra_aws_infra/campps_service_registry.py`), each
+  `infiquetra/campps-<name>`, default `serverless-api`, all 3 environments. The registry-driven
+  stack (`campps_deploy_roles_stack.py:49-68`) auto-mints a per-service, per-env OIDC deploy role +
+  3 managed policies + permissions boundary — **no new role code** (S4 #135 rides on S3 for the
+  backends, per KTD2).
+
+- **U2 — add the `web-app` deploy profile + register `campps-web-app` (S4, #135).** Authored
+  `_create_web_app_deploy_policy()` and a `deploy_profile == "web-app"` branch in
+  `_create_deploy_policies()`. Registered `campps-web-app` (`deploy_profile="web-app"`). The policy
+  is **provisional** (KTD3): shared CloudFormation + CDK-bootstrap baseline, S3 object/bucket ops
+  scoped to `campps-web-app-<env>-*`, CloudFront distribution + invalidation + OAC management — and
+  **no** Lambda / DynamoDB / API Gateway / EventBridge / SQS / Secrets Manager grants. CloudFront
+  create-class actions are on `*` (AWS has no resource-level IAM support for them); everything
+  scopable is pinned to this account's distributions.
+
+- **U3 — guard unrecognized profiles (KTD4).** Replaced the silent `serverless-api` default fallback
+  in `_create_deploy_policies()` with an explicit branch per known profile + a
+  `raise ValueError(f"unknown deploy_profile: {profile!r}")`. A profile typo can no longer silently
+  mint an over-privileged serverless-api role.
+
+## Key decisions honored
+
+- KTD1 canonical set sourced from `campps-context-library` phase-1a-build-program (10 backends +
+  web-app), not the conflicting "7 vs 10" card text.
+- KTD3 web-app profile shipped **provisional**, marked in code + DECISIONS; revisit when the real
+  web-app CDK stack lands (S3+CloudFront vs Amplify).
+- web-app reuses the generic permissions boundary; it is **inert** for web-app because the web-app
+  deploy policy grants no `iam:CreateRole` (no app role is ever created under that boundary). R4's
+  "permissions boundary per env exists" is still satisfied.
+
+## Files modified
+
+- `infiquetra_aws_infra/campps_service_registry.py` (+34): 6 backends + web-app, provisional comment.
+- `infiquetra_aws_infra/campps_deploy_roles_stack.py` (+122): web-app policy builder + explicit
+  profile branches + guard.
+- `tests/unit/test_campps_deploy_roles_stack.py` (+335, 17 new tests): canonical-set membership;
+  parametrized role+boundary+env-scoped-trust per serverless backend × env; web-app static-site
+  scope + no-backend-actions + size<6144 + env-scoped trust; unknown-profile raises.
+- `docs/engineering-journal/DECISIONS.md`, `.gitignore` (ignore `.claude/saga/`),
+  `docs/plans/...`, `docs/reviews/...` carried from `/plan` + `/doc-review`.
+
+## Checks run (evidence)
+
+- `ruff check .` → All checks passed. `ruff format` → clean.
+- `mypy .` → Success, no issues (17 source files).
+- `pytest` (full suite) → all pass; deploy-roles file 72 tests green.
+- `cdk synth --app "python3 app_campps_bootstrap.py"` → synthesizes all 3 envs × 11 services
+  (SYNTH_OK).
+
+## Next step
+
+Run the Phase-5 deep code-review gate (IAM least-privilege focus), then offer to open the PR
+(`infiquetra-aws-infra#134` + `#135`). U4 (nonprod apply + role-existence/trust verification) is
+**out of `/work` scope** — it routes to `/deploy` + `/qa` after merge (destination `nonprod-deploy`).

--- a/docs/work-sessions/2026-06-20-c0-3-service-registry-oidc.md
+++ b/docs/work-sessions/2026-06-20-c0-3-service-registry-oidc.md
@@ -64,8 +64,23 @@ status: PR-ready (pending review gate)
 - `cdk synth --app "python3 app_campps_bootstrap.py"` → synthesizes all 3 envs × 11 services
   (SYNTH_OK).
 
+## Code-review gate (Phase 5) — PASS
+
+- **Deep review** at `REVIEWED_SHA=cfb2a04`: a 5-lens adversarial workflow (IAM least-privilege /
+  built-vs-planned / guard+registry correctness / test false-confidence / OIDC trust), 5 agents,
+  ~352k tokens. Verdict **PASS — no P0/P1 (no P2)**; 6 P3 notes. Agents empirically validated
+  non-vacuity (injected `lambda:CreateFunction` → the no-backend-actions test failed as expected;
+  confirmed the `ValueError` guard fires at synth time).
+- **Acted on 2 P3 notes** (test hardening, commit `d66a087`, production code unchanged): added `web-app`
+  to `PROFILE_REPRESENTATIVE_REPOSITORIES` (now asserts web-app's `iam:PassRole`/`AssumeRole` scope +
+  size across all envs) and strengthened `test_known_deploy_profiles_do_not_raise` to assert each
+  profile mints a role + policy.
+- **Focused delta re-review** at `REVIEWED_SHA=d66a087`: PASS, no P0/P1/P2; production byte-identical to
+  `cfb2a04`; 43 tests green. Remaining P3 notes are documented-provisional (web-app static-site scope,
+  CloudFront `*` create-class, inert generic boundary) — tracked as KTD3 revisit follow-ups, not defects.
+
 ## Next step
 
-Run the Phase-5 deep code-review gate (IAM least-privilege focus), then offer to open the PR
-(`infiquetra-aws-infra#134` + `#135`). U4 (nonprod apply + role-existence/trust verification) is
-**out of `/work` scope** — it routes to `/deploy` + `/qa` after merge (destination `nonprod-deploy`).
+PR-ready. Offer to open the PR (`infiquetra-aws-infra#134` + `#135`) under operator confirmation. U4
+(nonprod apply + role-existence/trust verification) is **out of `/work` scope** — it routes to
+`/deploy` + `/qa` after merge (destination `nonprod-deploy`).

--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -252,15 +252,27 @@ class CamppsDeployRolesStack(Stack):
 
         ``serverless-api`` and ``platform-foundation`` each return a split set
         of managed policies to stay under the IAM managed-policy size limit.
-        The ``codeartifact-publish`` profile returns a single managed policy.
+        The ``codeartifact-publish`` and ``web-app`` profiles each return a
+        single managed policy.
+
+        Every recognized profile is matched explicitly; an unknown profile
+        raises rather than falling back to ``serverless-api``, so a typo can
+        never silently mint an over-privileged serverless-api role.
         """
-        if service_repository.deploy_profile == "platform-foundation":
+        profile = service_repository.deploy_profile
+        if profile == "serverless-api":
+            return self._create_serverless_api_deploy_policies(
+                service_repository=service_repository,
+                target_environment=target_environment,
+                permissions_boundary=permissions_boundary,
+            )
+        if profile == "platform-foundation":
             return self._create_platform_foundation_deploy_policies(
                 service_repository=service_repository,
                 target_environment=target_environment,
                 permissions_boundary=permissions_boundary,
             )
-        if service_repository.deploy_profile == "codeartifact-publish":
+        if profile == "codeartifact-publish":
             return (
                 self._create_codeartifact_publish_deploy_policy(
                     service_repository=service_repository,
@@ -268,11 +280,15 @@ class CamppsDeployRolesStack(Stack):
                     permissions_boundary=permissions_boundary,
                 ),
             )
-        return self._create_serverless_api_deploy_policies(
-            service_repository=service_repository,
-            target_environment=target_environment,
-            permissions_boundary=permissions_boundary,
-        )
+        if profile == "web-app":
+            return (
+                self._create_web_app_deploy_policy(
+                    service_repository=service_repository,
+                    target_environment=target_environment,
+                    permissions_boundary=permissions_boundary,
+                ),
+            )
+        raise ValueError(f"unknown deploy_profile: {profile!r}")
 
     def _codeartifact_domain_arn(self) -> str:
         return str(
@@ -485,6 +501,96 @@ class CamppsDeployRolesStack(Stack):
                         self._codeartifact_repository_arn(),
                         self._codeartifact_package_arn(),
                     ],
+                ),
+            ],
+        )
+
+    def _create_web_app_deploy_policy(
+        self,
+        *,
+        service_repository: ServiceRepository,
+        target_environment: DeployEnvironment,
+        permissions_boundary: iam.ManagedPolicy,
+    ) -> iam.ManagedPolicy:
+        """Least-privilege static-site (S3 + CloudFront) deploy policy.
+
+        PROVISIONAL (KTD3): ``campps-web-app`` is an empty scaffold today with
+        no settled deploy target, so this profile is scoped to the standard
+        static-site pattern — the shared CloudFormation + CDK-bootstrap
+        baseline, S3 object/bucket ops on the service's own
+        ``campps-web-app-<env>-*`` buckets, and CloudFront distribution +
+        invalidation + origin-access-control management. It deliberately grants
+        **no** Lambda / DynamoDB / API Gateway / EventBridge / SQS / Secrets
+        Manager actions. Revisit and tighten when the real web-app CDK stack
+        lands (it may be Amplify or differ). See
+        docs/plans/2026-06-20-c0-3-aws-infra-service-registry-oidc-plan.md.
+
+        CloudFront create-class actions
+        (``CreateDistribution``/``CreateOriginAccessControl``) do not support
+        resource-level IAM scoping, so they are granted on ``*``; everything
+        that can be scoped is pinned to this account's distributions.
+        """
+        prefix = f"campps-{service_repository.name}-{target_environment}"
+        site_bucket_arn = f"arn:aws:s3:::{prefix}-*"
+        distribution_arn = self.format_arn(
+            service="cloudfront",
+            region="",
+            resource="distribution",
+            resource_name="*",
+            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+        )
+        return iam.ManagedPolicy(
+            self,
+            f"{self._logical_id_prefix(service_repository.name)}DeployPolicy",
+            managed_policy_name=service_repository.policy_name(target_environment),
+            description=(
+                f"Static-site (S3 + CloudFront) deployment permissions for "
+                f"{service_repository.repository} {target_environment} "
+                f"(provisional)"
+            ),
+            statements=[
+                *self._cloudformation_baseline_statements(prefix=prefix),
+                iam.PolicyStatement(
+                    sid="StaticSiteBucket",
+                    actions=[
+                        "s3:CreateBucket",
+                        "s3:DeleteObject",
+                        "s3:GetBucketLocation",
+                        "s3:GetBucketPolicy",
+                        "s3:GetBucketWebsite",
+                        "s3:GetEncryptionConfiguration",
+                        "s3:GetObject",
+                        "s3:ListBucket",
+                        "s3:PutBucketPolicy",
+                        "s3:PutBucketWebsite",
+                        "s3:PutEncryptionConfiguration",
+                        "s3:PutObject",
+                    ],
+                    resources=[site_bucket_arn, f"{site_bucket_arn}/*"],
+                ),
+                iam.PolicyStatement(
+                    sid="CloudFrontDistributionManagement",
+                    actions=[
+                        "cloudfront:CreateInvalidation",
+                        "cloudfront:GetDistribution",
+                        "cloudfront:GetDistributionConfig",
+                        "cloudfront:TagResource",
+                        "cloudfront:UntagResource",
+                        "cloudfront:UpdateDistribution",
+                    ],
+                    resources=[distribution_arn],
+                ),
+                iam.PolicyStatement(
+                    sid="CloudFrontCreateAndOriginAccessControl",
+                    actions=[
+                        "cloudfront:CreateDistribution",
+                        "cloudfront:CreateDistributionWithTags",
+                        "cloudfront:CreateOriginAccessControl",
+                        "cloudfront:GetOriginAccessControl",
+                    ],
+                    # CloudFront create-class actions have no resource-level
+                    # IAM support; "*" is the AWS-documented requirement here.
+                    resources=["*"],
                 ),
             ],
         )

--- a/infiquetra_aws_infra/campps_service_registry.py
+++ b/infiquetra_aws_infra/campps_service_registry.py
@@ -51,4 +51,38 @@ CAMPPS_SERVICE_REPOSITORIES: tuple[ServiceRepository, ...] = (
         name="tenant-setup",
         repository="infiquetra/campps-tenant-setup",
     ),
+    ServiceRepository(
+        name="coppa-consent",
+        repository="infiquetra/campps-coppa-consent",
+    ),
+    ServiceRepository(
+        name="registration",
+        repository="infiquetra/campps-registration",
+    ),
+    ServiceRepository(
+        name="payments",
+        repository="infiquetra/campps-payments",
+    ),
+    ServiceRepository(
+        name="health-forms",
+        repository="infiquetra/campps-health-forms",
+    ),
+    ServiceRepository(
+        name="activities-achievements",
+        repository="infiquetra/campps-activities-achievements",
+    ),
+    ServiceRepository(
+        name="staff-management",
+        repository="infiquetra/campps-staff-management",
+    ),
+    # Provisional: campps-web-app is an empty scaffold today with no settled
+    # deploy target. The web-app profile is scoped to the standard static-site
+    # pattern (S3 + CloudFront) and MUST be revisited when the real web-app CDK
+    # stack lands (it may be Amplify or differ). See KTD3 in
+    # docs/plans/2026-06-20-c0-3-aws-infra-service-registry-oidc-plan.md.
+    ServiceRepository(
+        name="web-app",
+        repository="infiquetra/campps-web-app",
+        deploy_profile="web-app",
+    ),
 )

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Iterable
 from typing import Any
 
+import pytest
 from aws_cdk import App, Environment
 from aws_cdk.assertions import Template
 
@@ -138,27 +139,108 @@ def managed_policy_document_sizes(template: Template) -> dict[str, int]:
     }
 
 
-def test_default_registry_includes_current_service_repositories() -> None:
-    assert (
-        ServiceRepository(
-            name="platform",
-            repository="infiquetra/campps-platform",
-            deploy_profile="platform-foundation",
-        ),
-        ServiceRepository(
-            name="contracts",
-            repository="infiquetra/campps-contracts",
-            deploy_profile="codeartifact-publish",
-        ),
-        ServiceRepository(
-            name="identity-access",
-            repository="infiquetra/campps-identity-access",
-        ),
-        ServiceRepository(
-            name="tenant-setup",
-            repository="infiquetra/campps-tenant-setup",
-        ),
-    ) == CAMPPS_SERVICE_REPOSITORIES
+# The canonical CAMPPS deployable set, grounded in campps-context-library
+# phase-1a-build-program.md (KTD1): 10 serverless-api backends + the web-app
+# frontend. Membership equality is asserted exactly so adding/removing a
+# service is a deliberate, reviewed change.
+CANONICAL_SERVICE_REPOSITORIES: tuple[ServiceRepository, ...] = (
+    ServiceRepository(
+        name="platform",
+        repository="infiquetra/campps-platform",
+        deploy_profile="platform-foundation",
+    ),
+    ServiceRepository(
+        name="contracts",
+        repository="infiquetra/campps-contracts",
+        deploy_profile="codeartifact-publish",
+    ),
+    ServiceRepository(
+        name="identity-access",
+        repository="infiquetra/campps-identity-access",
+    ),
+    ServiceRepository(
+        name="tenant-setup",
+        repository="infiquetra/campps-tenant-setup",
+    ),
+    ServiceRepository(
+        name="coppa-consent",
+        repository="infiquetra/campps-coppa-consent",
+    ),
+    ServiceRepository(
+        name="registration",
+        repository="infiquetra/campps-registration",
+    ),
+    ServiceRepository(
+        name="payments",
+        repository="infiquetra/campps-payments",
+    ),
+    ServiceRepository(
+        name="health-forms",
+        repository="infiquetra/campps-health-forms",
+    ),
+    ServiceRepository(
+        name="activities-achievements",
+        repository="infiquetra/campps-activities-achievements",
+    ),
+    ServiceRepository(
+        name="staff-management",
+        repository="infiquetra/campps-staff-management",
+    ),
+    ServiceRepository(
+        name="web-app",
+        repository="infiquetra/campps-web-app",
+        deploy_profile="web-app",
+    ),
+)
+
+# The 10 deployable backends are all serverless-api except the two
+# special-profile services (platform, contracts).
+EXPECTED_SERVERLESS_API_BACKENDS = frozenset(
+    {
+        "identity-access",
+        "tenant-setup",
+        "coppa-consent",
+        "registration",
+        "payments",
+        "health-forms",
+        "activities-achievements",
+        "staff-management",
+    }
+)
+
+
+def test_registry_membership_equals_canonical_set() -> None:
+    assert CAMPPS_SERVICE_REPOSITORIES == CANONICAL_SERVICE_REPOSITORIES
+
+
+def test_registry_has_ten_backends_plus_web_app() -> None:
+    backends = [
+        service
+        for service in CAMPPS_SERVICE_REPOSITORIES
+        if service.deploy_profile != "web-app"
+    ]
+    web_apps = [
+        service
+        for service in CAMPPS_SERVICE_REPOSITORIES
+        if service.deploy_profile == "web-app"
+    ]
+
+    assert len(backends) == 10, [service.name for service in backends]
+    assert [service.name for service in web_apps] == ["web-app"]
+
+
+def test_every_service_repository_targets_all_three_environments() -> None:
+    for service in CAMPPS_SERVICE_REPOSITORIES:
+        assert service.environments == ("nonprod", "staging", "production"), service
+
+
+def test_serverless_api_backends_use_default_profile() -> None:
+    serverless_backends = {
+        service.name
+        for service in CAMPPS_SERVICE_REPOSITORIES
+        if service.deploy_profile == "serverless-api"
+    }
+    assert serverless_backends == EXPECTED_SERVERLESS_API_BACKENDS
 
 
 def test_deploy_role_uses_service_and_environment_name() -> None:
@@ -949,3 +1031,210 @@ def test_codeartifact_publish_role_can_publish_package_versions() -> None:
     actions = {action.lower() for action in collect_actions(template)}
     assert "sts:getservicebearertoken" in actions
     assert "codeartifact:getauthorizationtoken" in actions
+
+
+# --- U1: every registered service mints a scoped, env-bound deploy role -------
+
+NEW_BACKEND_SERVICES: tuple[ServiceRepository, ...] = tuple(
+    service
+    for service in CANONICAL_SERVICE_REPOSITORIES
+    if service.name in EXPECTED_SERVERLESS_API_BACKENDS
+)
+
+
+def find_managed_policy(template: Template, policy_name: str) -> dict[str, Any]:
+    policies = template.find_resources("AWS::IAM::ManagedPolicy")
+    matching = [
+        policy
+        for policy in policies.values()
+        if policy.get("Properties", {}).get("ManagedPolicyName") == policy_name
+    ]
+    assert len(matching) == 1, (policy_name, list(policies))
+    return dict(matching[0])
+
+
+def test_every_serverless_backend_mints_role_and_boundary_per_environment() -> None:
+    for service in NEW_BACKEND_SERVICES:
+        for environment in DEPLOY_ENVIRONMENTS:
+            template = synth_template_for_repositories(
+                service, target_environment=environment
+            )
+
+            template.has_resource_properties(
+                "AWS::IAM::Role",
+                {"RoleName": service.role_name(environment)},
+            )
+            template.has_resource_properties(
+                "AWS::IAM::ManagedPolicy",
+                {"ManagedPolicyName": service.permissions_boundary_name(environment)},
+            )
+            # Trust is pinned to the exact repo + environment OIDC subject.
+            role = find_deploy_role(template, service.role_name(environment))
+            statement = get_assume_role_statement(role)
+            assert statement["Condition"]["StringEquals"][
+                "token.actions.githubusercontent.com:sub"
+            ] == (f"repo:{service.repository}:environment:{environment}"), (
+                service.name,
+                environment,
+            )
+
+
+def test_full_registry_synthesizes_a_role_for_each_in_scope_service() -> None:
+    for environment in DEPLOY_ENVIRONMENTS:
+        template = synth_template_for_repositories(
+            *CANONICAL_SERVICE_REPOSITORIES, target_environment=environment
+        )
+        for service in CANONICAL_SERVICE_REPOSITORIES:
+            if environment not in service.environments:
+                continue
+            template.has_resource_properties(
+                "AWS::IAM::Role",
+                {"RoleName": service.role_name(environment)},
+            )
+
+
+# --- U2: web-app gets a least-privilege static-site profile --------------------
+
+WEB_APP_SERVICE = ServiceRepository(
+    name="web-app",
+    repository="infiquetra/campps-web-app",
+    deploy_profile="web-app",
+)
+
+WEB_APP_FORBIDDEN_BACKEND_SERVICES = (
+    "lambda",
+    "dynamodb",
+    "apigateway",
+    "events",
+    "sqs",
+    "secretsmanager",
+)
+
+
+def web_app_deploy_policy_document(template: Template) -> dict[str, Any]:
+    policy = find_managed_policy(template, WEB_APP_SERVICE.policy_name("nonprod"))
+    return dict(policy["Properties"]["PolicyDocument"])
+
+
+def test_web_app_role_exists_with_env_scoped_trust() -> None:
+    for environment in DEPLOY_ENVIRONMENTS:
+        template = synth_template_for_repositories(
+            WEB_APP_SERVICE, target_environment=environment
+        )
+
+        role_name = f"campps-web-app-{environment}-gha-deploy-role"
+        template.has_resource_properties("AWS::IAM::Role", {"RoleName": role_name})
+        role = find_deploy_role(template, role_name)
+        statement = get_assume_role_statement(role)
+        assert statement["Condition"]["StringEquals"][
+            "token.actions.githubusercontent.com:sub"
+        ] == (f"repo:infiquetra/campps-web-app:environment:{environment}"), environment
+
+
+def test_web_app_policy_grants_pinned_static_site_actions() -> None:
+    template = synth_template_for_repositories(WEB_APP_SERVICE)
+    document = web_app_deploy_policy_document(template)
+
+    actions = {
+        action.lower()
+        for statement in document["Statement"]
+        for action in normalize_actions(statement.get("Action", []))
+    }
+    # The static-site write paths the plan pins.
+    assert "s3:putobject" in actions
+    assert "s3:createbucket" in actions
+    assert "s3:putbucketwebsite" in actions
+    assert "cloudfront:createinvalidation" in actions
+    assert "cloudfront:createdistribution" in actions
+    assert "cloudfront:createoriginaccesscontrol" in actions
+
+
+def test_web_app_s3_actions_are_scoped_to_service_buckets() -> None:
+    template = synth_template_for_repositories(WEB_APP_SERVICE)
+    document = web_app_deploy_policy_document(template)
+
+    s3_statements = [
+        statement
+        for statement in document["Statement"]
+        if any(
+            action.lower().startswith("s3:")
+            for action in normalize_actions(statement.get("Action", []))
+        )
+        # Skip the shared CDK-assets baseline statement (cdk-hnb659fds bucket).
+        and statement.get("Sid") == "StaticSiteBucket"
+    ]
+    assert s3_statements
+    for statement in s3_statements:
+        resources = tuple(normalize_resources(statement.get("Resource", [])))
+        assert resources, statement
+        for resource in resources:
+            assert resource.startswith("arn:aws:s3:::campps-web-app-nonprod-*"), (
+                resource
+            )
+            assert resource != "*"
+
+
+def test_web_app_policy_grants_no_backend_service_actions() -> None:
+    template = synth_template_for_repositories(WEB_APP_SERVICE)
+    document = web_app_deploy_policy_document(template)
+
+    granted_services = {
+        action.split(":", maxsplit=1)[0].lower()
+        for statement in document["Statement"]
+        for action in normalize_actions(statement.get("Action", []))
+    }
+    for forbidden in WEB_APP_FORBIDDEN_BACKEND_SERVICES:
+        assert forbidden not in granted_services, (forbidden, sorted(granted_services))
+
+
+def test_web_app_policy_fits_iam_size_limit() -> None:
+    for environment in DEPLOY_ENVIRONMENTS:
+        template = synth_template_for_repositories(
+            WEB_APP_SERVICE, target_environment=environment
+        )
+        sizes = managed_policy_document_sizes(template)
+        deploy_policy_sizes = {
+            name: size
+            for name, size in sizes.items()
+            if name.startswith("campps-web-app-") and "permissions-boundary" not in name
+        }
+        assert deploy_policy_sizes
+        for name, size in deploy_policy_sizes.items():
+            assert size < IAM_MANAGED_POLICY_SIZE_LIMIT, (name, size, environment)
+
+
+# --- U3: an unrecognized deploy profile is a hard error, not a silent default --
+
+
+def test_unknown_deploy_profile_raises() -> None:
+    with pytest.raises(ValueError, match="unknown deploy_profile"):
+        synth_template_for_repositories(
+            ServiceRepository(
+                name="bogus",
+                repository="infiquetra/campps-bogus",
+                deploy_profile="not-a-real-profile",
+            )
+        )
+
+
+def test_known_deploy_profiles_do_not_raise() -> None:
+    for service in (
+        ServiceRepository(name="a", repository="infiquetra/campps-a"),
+        ServiceRepository(
+            name="b",
+            repository="infiquetra/campps-b",
+            deploy_profile="platform-foundation",
+        ),
+        ServiceRepository(
+            name="c",
+            repository="infiquetra/campps-c",
+            deploy_profile="codeartifact-publish",
+        ),
+        ServiceRepository(
+            name="d",
+            repository="infiquetra/campps-d",
+            deploy_profile="web-app",
+        ),
+    ):
+        # Should synthesize without raising.
+        synth_template_for_repositories(service)

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -267,6 +267,11 @@ PROFILE_REPRESENTATIVE_REPOSITORIES: tuple[ServiceRepository, ...] = (
         repository="infiquetra/campps-contracts",
         deploy_profile="codeartifact-publish",
     ),
+    ServiceRepository(
+        name="web-app",
+        repository="infiquetra/campps-web-app",
+        deploy_profile="web-app",
+    ),
 )
 
 IAM_MANAGED_POLICY_SIZE_LIMIT = 6144
@@ -1236,5 +1241,14 @@ def test_known_deploy_profiles_do_not_raise() -> None:
             deploy_profile="web-app",
         ),
     ):
-        # Should synthesize without raising.
-        synth_template_for_repositories(service)
+        # Each known profile must synthesize *and* actually mint a deploy role
+        # plus its managed deploy policy — not merely fail to raise.
+        template = synth_template_for_repositories(service)
+        template.has_resource_properties(
+            "AWS::IAM::Role",
+            {"RoleName": service.role_name("nonprod")},
+        )
+        template.has_resource_properties(
+            "AWS::IAM::ManagedPolicy",
+            {"ManagedPolicyName": service.policy_name("nonprod")},
+        )


### PR DESCRIPTION
## Summary

Registers all CAMPPS deployable services in the registry-driven deploy-roles stack and adds a
least-privilege `web-app` deploy profile, so every service gets a correctly-scoped per-environment
GitHub OIDC deploy role.

- **U1 — register the 6 missing backend services (#134).** `coppa-consent`, `registration`,
  `payments`, `health-forms`, `activities-achievements`, `staff-management` — each
  `infiquetra/campps-<name>`, default `serverless-api`, all 3 environments. The registry-driven stack
  auto-mints each service's per-env OIDC deploy role + 3 managed policies + permissions boundary, so S4
  (#135) rides on the registry edit with **no new role code** for the backends.
- **U2 — add the `web-app` deploy profile + register `campps-web-app` (#135).** New
  `_create_web_app_deploy_policy()` scoped to static-site hosting: the shared CloudFormation +
  CDK-bootstrap baseline, S3 object/bucket ops on `campps-web-app-<env>-*`, and CloudFront distribution
  + invalidation + origin-access-control management. It carries **no** Lambda / DynamoDB / API Gateway /
  EventBridge / SQS / Secrets Manager grants — a Flutter Web static client never needs them.
- **U3 — guard unrecognized profiles.** `_create_deploy_policies()` now matches every known profile
  explicitly and **raises `ValueError`** on anything else, instead of silently defaulting to the
  over-privileged `serverless-api` policy set.

## Key decisions

- Canonical service set sourced from `campps-context-library` phase-1a-build-program (10 backends +
  web-app), not the conflicting "7 vs 10" card text (KTD1).
- The `web-app` profile is **provisional** (KTD3): `campps-web-app` is an empty scaffold today, so the
  profile is scoped to the standard static-site pattern and **must be revisited** when its real CDK
  stack lands (it may be Amplify or differ). CloudFront create-class actions are on `*` because AWS has
  no resource-level IAM support for them.

## Test plan

- [x] `ruff check .` / `ruff format` — clean
- [x] `mypy .` (strict) — no issues
- [x] `pytest` (full suite) — green; 17 new tests cover canonical membership, per-service
      role/boundary/env-scoped-trust, web-app static-site scope + absence of backend actions + IAM size
      limit, and the unknown-profile guard
- [x] `cdk synth --app "python3 app_campps_bootstrap.py"` — synthesizes all 3 envs × 11 services
- [x] Deep multi-agent IAM-scoping code-review at the work→PR boundary

## Out of scope / deferred

- **U4 nonprod apply + role-existence/trust verification** routes to `/deploy` + `/qa` after merge
  (destination `nonprod-deploy`); staging/production deploys are a later reviewer-gated `/deploy` (KTD5).
- **Live OIDC assume proof** (#135 AC) is deferred — the 6 new service repos are bare scaffolds with no
  deploy workflow to mint a token; this slice proves role *provisioning* + correct env-scoped trust.

## Artifacts

- Plan: `docs/plans/2026-06-20-c0-3-aws-infra-service-registry-oidc-plan.md`
- Doc-review: `docs/reviews/2026-06-20-c0-3-aws-infra-service-registry-oidc-review.md`
- Work session: `docs/work-sessions/2026-06-20-c0-3-service-registry-oidc.md`

Refs infiquetra-aws-infra#134, infiquetra-aws-infra#135 · parent campps-platform#10

https://claude.ai/code/session_019MQJTBjRGhZruZA2tJKmX3
