### PR TITLE
feat(deploy-roles): grant tenant-setup nonprod deploy role scope-origination seam-proof permissions

### DIFF
--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -25,6 +25,25 @@
 
 ---
 
+## 2026-06-23
+
+### Cross-service deploy-role grant for the scope-origination seam proof (tenant-setup nonprod only)
+
+**Decision.** Add a single narrowly-scoped managed policy (`campps-tenant-setup-nonprod-gha-seam-proof-policy`) to the tenant-setup nonprod deploy role, granting `events:PutEvents` on the shared platform bus (`campps-platform-nonprod`) and `dynamodb:GetItem` on identity-access's table (`campps-identity-access-nonprod`). This unblocks the deploy-gated integration test `tests/integration/test_scope_origination_seam_deployed.py` (campps-tenant-setup PR #67), which proves the producer → bus → consumer seam end-to-end against real deployed infrastructure. The grant is implemented as a standalone method `_create_scope_seam_proof_policy` that returns `None` for every service/environment combination except `tenant-setup` + `nonprod`, so the guard is co-located with the grant and easy to audit.
+
+**Rejected alternatives.**
+- Dedicated seam-proof IAM role: adds OIDC trust configuration, a second role ARN to thread through CI, and operational complexity — disproportionate for a two-action grant that runs in a single lane.
+- Broadening the permissions boundary: the boundary governs app-role creation, not the deploy role itself; touching it for a deploy-time test concern mixes two distinct scopes.
+- Granting staging/production as well: the proof only runs in the nonprod lane; granting production/staging deploy roles read into identity-access's table would be speculative privilege with no corresponding test gate.
+
+**Implementation.** `infiquetra_aws_infra/campps_deploy_roles_stack.py` — method `_create_scope_seam_proof_policy`; `tests/unit/test_campps_deploy_roles_stack.py` — one positive test + three negative tests.
+
+**Revisit when.** The seam proof is extended to staging or production lanes (at that point, extend the guard condition and add corresponding tests); or the proof is retired (remove the method and its call site).
+
+**Commit.** PR feat/l1-a-seam-proof-deploy-grant / campps-tenant-setup PR #67.
+
+---
+
 ## 2026-06-20
 
 ### C0.3 — register all CAMPPS services + add a `web-app` deploy profile

--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -67,6 +67,13 @@ class CamppsDeployRolesStack(Stack):
             for deploy_policy in deploy_policies:
                 deploy_role.add_managed_policy(deploy_policy)
 
+            seam_proof_policy = self._create_scope_seam_proof_policy(
+                service_repository=service_repository,
+                target_environment=target_environment,
+            )
+            if seam_proof_policy is not None:
+                deploy_role.add_managed_policy(seam_proof_policy)
+
             CfnOutput(
                 self,
                 f"{self._logical_id_prefix(service_repository.name)}DeployRoleArn",
@@ -1581,6 +1588,69 @@ class CamppsDeployRolesStack(Stack):
                     ),
                 ],
             ),
+        )
+
+    def _create_scope_seam_proof_policy(
+        self,
+        *,
+        service_repository: ServiceRepository,
+        target_environment: DeployEnvironment,
+    ) -> iam.ManagedPolicy | None:
+        """Cross-service grant for the deploy-gated scope-origination seam proof.
+
+        campps-tenant-setup's nonprod deploy lane runs
+        ``tests/integration/test_scope_origination_seam_deployed.py`` (PR #67):
+        it emits a real ``CampDefinitionChanged`` to the shared platform bus and
+        reads back the ``ResourceScope`` row that identity-access projects,
+        proving the producer -> bus -> consumer seam end-to-end against deployed
+        infrastructure. The deploy role needs ``events:PutEvents`` on the platform
+        bus and ``dynamodb:GetItem`` on identity's table to run that proof.
+
+        Scoped to tenant-setup + nonprod only: the proof runs only in the nonprod
+        lane, and granting a staging/production deploy role read access into
+        identity's table would be speculative privilege. Extend per environment
+        only when those lanes also run the proof.
+        """
+        if service_repository.name != "tenant-setup" or target_environment != "nonprod":
+            return None
+        return iam.ManagedPolicy(
+            self,
+            f"{self._logical_id_prefix(service_repository.name)}ScopeSeamProofPolicy",
+            managed_policy_name=(
+                f"campps-{service_repository.name}-{target_environment}"
+                "-gha-seam-proof-policy"
+            ),
+            description=(
+                "Cross-service deploy-gated scope-origination seam proof grant "
+                f"for {service_repository.repository} {target_environment} "
+                "(campps-tenant-setup PR #67)"
+            ),
+            statements=[
+                iam.PolicyStatement(
+                    sid="ScopeSeamProducerEmit",
+                    actions=["events:PutEvents"],
+                    resources=[
+                        self.format_arn(
+                            service="events",
+                            resource="event-bus",
+                            resource_name=f"campps-platform-{target_environment}",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                ),
+                iam.PolicyStatement(
+                    sid="ScopeSeamConsumerReadback",
+                    actions=["dynamodb:GetItem"],
+                    resources=[
+                        self.format_arn(
+                            service="dynamodb",
+                            resource="table",
+                            resource_name=f"campps-identity-access-{target_environment}",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                ),
+            ],
         )
 
     @staticmethod

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -1330,3 +1330,98 @@ def test_known_deploy_profiles_do_not_raise() -> None:
             "AWS::IAM::ManagedPolicy",
             {"ManagedPolicyName": service.policy_name("nonprod")},
         )
+
+
+# --- campps-tenant-setup PR #67: scope-origination seam proof grant --------
+#
+# The nonprod deploy role for tenant-setup needs two cross-service permissions
+# to run tests/integration/test_scope_origination_seam_deployed.py:
+#   - events:PutEvents on the shared platform bus (campps-platform-nonprod)
+#   - dynamodb:GetItem on identity-access's table (campps-identity-access-nonprod)
+#
+# The grant is scoped to tenant-setup + nonprod only.
+
+TENANT_SETUP_REPO = ServiceRepository(
+    name="tenant-setup",
+    repository="infiquetra/campps-tenant-setup",
+)
+
+SEAM_PROOF_POLICY_NAME = "campps-tenant-setup-nonprod-gha-seam-proof-policy"
+
+
+def test_tenant_setup_nonprod_deploy_role_has_seam_proof_policy() -> None:
+    """Positive: tenant-setup nonprod role is attached to the seam proof policy
+    and that policy contains exactly the two scoped cross-service grants."""
+    template = synth_template_for_repositories(
+        TENANT_SETUP_REPO, target_environment="nonprod"
+    )
+
+    # The policy must exist with the expected name.
+    policy = find_managed_policy(template, SEAM_PROOF_POLICY_NAME)
+    document = policy["Properties"]["PolicyDocument"]
+
+    statements_by_sid = {
+        stmt["Sid"]: stmt for stmt in document["Statement"] if "Sid" in stmt
+    }
+
+    # ScopeSeamProducerEmit: events:PutEvents on the platform bus.
+    assert "ScopeSeamProducerEmit" in statements_by_sid, statements_by_sid.keys()
+    producer_stmt = statements_by_sid["ScopeSeamProducerEmit"]
+    assert set(normalize_actions(producer_stmt["Action"])) == {"events:PutEvents"}
+    producer_resources = str(producer_stmt["Resource"])
+    assert "event-bus/campps-platform-nonprod" in producer_resources, producer_resources
+
+    # ScopeSeamConsumerReadback: dynamodb:GetItem on identity-access's table.
+    assert "ScopeSeamConsumerReadback" in statements_by_sid, statements_by_sid.keys()
+    consumer_stmt = statements_by_sid["ScopeSeamConsumerReadback"]
+    assert set(normalize_actions(consumer_stmt["Action"])) == {"dynamodb:GetItem"}
+    consumer_resources = str(consumer_stmt["Resource"])
+    assert "table/campps-identity-access-nonprod" in consumer_resources, (
+        consumer_resources
+    )
+
+
+def test_tenant_setup_staging_has_no_seam_proof_policy() -> None:
+    """Negative: no seam-proof policy is synthesized for tenant-setup staging."""
+    template = synth_template_for_repositories(
+        TENANT_SETUP_REPO, target_environment="staging"
+    )
+    policy_names = {
+        policy.get("Properties", {}).get("ManagedPolicyName")
+        for policy in template.find_resources("AWS::IAM::ManagedPolicy").values()
+    }
+    assert not any(
+        name is not None and "gha-seam-proof-policy" in name for name in policy_names
+    ), f"Unexpected seam-proof policy in staging: {policy_names}"
+
+
+def test_tenant_setup_production_has_no_seam_proof_policy() -> None:
+    """Negative: no seam-proof policy is synthesized for tenant-setup production."""
+    template = synth_template_for_repositories(
+        TENANT_SETUP_REPO, target_environment="production"
+    )
+    policy_names = {
+        policy.get("Properties", {}).get("ManagedPolicyName")
+        for policy in template.find_resources("AWS::IAM::ManagedPolicy").values()
+    }
+    assert not any(
+        name is not None and "gha-seam-proof-policy" in name for name in policy_names
+    ), f"Unexpected seam-proof policy in production: {policy_names}"
+
+
+def test_identity_access_nonprod_has_no_seam_proof_policy() -> None:
+    """Negative: no seam-proof policy is synthesized for identity-access nonprod."""
+    template = synth_template_for_repositories(
+        ServiceRepository(
+            name="identity-access",
+            repository="infiquetra/campps-identity-access",
+        ),
+        target_environment="nonprod",
+    )
+    policy_names = {
+        policy.get("Properties", {}).get("ManagedPolicyName")
+        for policy in template.find_resources("AWS::IAM::ManagedPolicy").values()
+    }
+    assert not any(
+        name is not None and "gha-seam-proof-policy" in name for name in policy_names
+    ), f"Unexpected seam-proof policy for identity-access: {policy_names}"


### PR DESCRIPTION
## Summary

- Adds `_create_scope_seam_proof_policy` to `CamppsDeployRolesStack`, returning a managed policy (`campps-tenant-setup-nonprod-gha-seam-proof-policy`) only when `service_repository.name == "tenant-setup"` and `target_environment == "nonprod"` — returns `None` for all other combinations.
- Attaches that policy to the deploy role inside the per-service loop, immediately after the existing deploy-policy loop.
- The policy grants exactly two actions: `events:PutEvents` on `arn:aws:events:us-east-1:477152411873:event-bus/campps-platform-nonprod` and `dynamodb:GetItem` on `arn:aws:dynamodb:us-east-1:477152411873:table/campps-identity-access-nonprod`.

## Why

campps-tenant-setup PR #67 adds `tests/integration/test_scope_origination_seam_deployed.py`, a deploy-gated real-bus integration proof that emits a `CampDefinitionChanged` event to the shared platform bus and reads back the `ResourceScope` row that identity-access projects, proving the full producer → bus → consumer seam against deployed infrastructure. The nonprod deploy role (`campps-tenant-setup-nonprod-gha-deploy-role`) had neither permission, so the gate was RED. Scoped to tenant-setup + nonprod only; granting staging/production deploy roles read into identity-access's table before those lanes run the proof would be speculative privilege.

## Test plan

- [ ] `uv run ruff check .` — passes (verified locally)
- [ ] `uv run ruff format .` — no diff (verified locally)
- [ ] `uv run mypy infiquetra_aws_infra` — clean (verified locally)
- [ ] `uv run pytest tests/unit/test_campps_deploy_roles_stack.py` — 49 passed (45 pre-existing + 4 new)
- [ ] `cdk synth CamppsNonProdDeployRolesStack` — `ScopeSeamProducerEmit` and `ScopeSeamConsumerReadback` each appear exactly once, attached to `campps-tenant-setup-nonprod-gha-deploy-role` (verified locally)
- [ ] Staging and production templates contain no `ScopeSeam` entries (verified locally)
- [ ] All pre-commit hooks (ruff, ruff-format, mypy, bandit) passed at commit time

https://claude.ai/code/session_01BT59CkXNJ62c78jDwcVhj6