### PR TITLE
fix(deploy): let web app fetch contract assets

### DIFF
--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -343,8 +343,16 @@ class CamppsDeployRolesStack(Stack):
             ),
             iam.PolicyStatement(
                 sid="CodeArtifactConsumeRead",
-                actions=["codeartifact:ReadFromRepository"],
-                resources=[self._codeartifact_repository_arn()],
+                actions=[
+                    "codeartifact:DescribePackageVersion",
+                    "codeartifact:GetPackageVersionAsset",
+                    "codeartifact:ListPackageVersionAssets",
+                    "codeartifact:ReadFromRepository",
+                ],
+                resources=[
+                    self._codeartifact_repository_arn(),
+                    self._codeartifact_package_arn(),
+                ],
             ),
             iam.PolicyStatement(
                 sid="CodeArtifactBearerToken",
@@ -557,6 +565,7 @@ class CamppsDeployRolesStack(Stack):
             ),
             statements=[
                 *self._cloudformation_baseline_statements(prefix=prefix),
+                *self._codeartifact_consume_statements(),
                 iam.PolicyStatement(
                     sid="StaticSiteBucket",
                     actions=[

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -1070,6 +1070,30 @@ def test_codeartifact_publish_role_can_publish_package_versions() -> None:
     assert "codeartifact:getauthorizationtoken" in actions
 
 
+def test_web_app_role_can_fetch_pinned_contract_assets() -> None:
+    template = synth_template_for_repositories(
+        ServiceRepository(
+            name="web-app",
+            repository="infiquetra/campps-web-app",
+            deploy_profile="web-app",
+        )
+    )
+
+    asset_reads = statements_for_action(
+        template,
+        "codeartifact:getpackageversionasset",
+    )
+    assert asset_reads
+    assert any(
+        ":package/infiquetra/campps/*" in str(statement.get("Resource"))
+        for statement in asset_reads
+    )
+
+    actions = {action.lower() for action in collect_actions(template)}
+    assert "sts:getservicebearertoken" in actions
+    assert "codeartifact:getauthorizationtoken" in actions
+
+
 # --- U1: every registered service mints a scoped, env-bound deploy role -------
 
 NEW_BACKEND_SERVICES: tuple[ServiceRepository, ...] = tuple(


### PR DESCRIPTION
## Summary
- grant CodeArtifact generic package asset read in the shared consumer policy
- attach CodeArtifact consume permissions to the web-app deploy profile
- add a deploy-role regression test for `codeartifact:GetPackageVersionAsset` on package resources

## Validation
- `uv run pytest tests/unit/test_campps_deploy_roles_stack.py -q`
- `uv run ruff check infiquetra_aws_infra/campps_deploy_roles_stack.py tests/unit/test_campps_deploy_roles_stack.py`
- `uv run ruff format --check infiquetra_aws_infra/campps_deploy_roles_stack.py tests/unit/test_campps_deploy_roles_stack.py`

Outcome #38 evidence: campps-web-app PR #60 CI run 28120912291 failed at `tool/fetch_contracts.sh` because the web-app nonprod GHA role lacked `codeartifact:GetPackageVersionAsset`.
