### PR TITLE
fix(deploy): grant e2e canary identity scope readback

### DIFF
--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -36,11 +36,11 @@
 - Add `Query`, `Scan`, batch reads, or table wildcards: unnecessary for the live proof, which requires one `GetItem` against the identity-access nonprod table.
 - Add staging or production grants: speculative privilege with no matching e2e-canary lane or live proof requirement.
 
-**Implementation.** Plan: `docs/plans/2026-07-02-e2e-canary-identity-scope-readback-iam-plan.md`. Expected code surfaces: `infiquetra_aws_infra/campps_deploy_roles_stack.py` and `tests/unit/test_campps_deploy_roles_stack.py`.
+**Implementation.** `infiquetra_aws_infra/campps_deploy_roles_stack.py` — method `_create_e2e_canary_identity_scope_readback_policy`; `tests/unit/test_campps_deploy_roles_stack.py` — positive role/policy attachment test plus higher-environment, helper-guard, unrelated-service, and tenant-setup regression coverage. Plan: `docs/plans/2026-07-02-e2e-canary-identity-scope-readback-iam-plan.md`.
 
 **Revisit when.** The e2e canary proof runs in staging/production, the readback shape needs a different DynamoDB operation, or a second fixture needs a similar grant and the helper pattern should become a small reusable optional-policy registry.
 
-**Commit.** Planned; implementation pending.
+**Commit.** Branch `fix/e2e-canary-identity-scope-readback`, implementation commit `ac0b543`.
 
 ---
 

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -40,7 +40,7 @@
 
 **Revisit when.** The e2e canary proof runs in staging/production, the readback shape needs a different DynamoDB operation, or a second fixture needs a similar grant and the helper pattern should become a small reusable optional-policy registry.
 
-**Commit.** Branch `fix/e2e-canary-identity-scope-readback`, implementation commit `ac0b543`.
+**Commit.** PR #142, branch `fix/e2e-canary-identity-scope-readback`, implementation commit `ac0b543`; nonprod deploy completed for `CamppsNonProdDeployRolesStack` and IAM simulation returned `allowed`.
 
 ---
 

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -25,6 +25,25 @@
 
 ---
 
+## 2026-07-02
+
+### E2E canary identity-scope readback grant (nonprod only)
+
+**Decision.** Plan a single narrowly-scoped managed policy for `campps-e2e-canary-nonprod-gha-deploy-role`, granting only `dynamodb:GetItem` on `campps-identity-access-nonprod`. The grant should be implemented as a standalone optional helper in `CamppsDeployRolesStack`, gated to `e2e-canary` + `nonprod`, mirroring the tenant-setup seam-proof helper instead of broadening the shared `serverless-api` deploy policy.
+
+**Rejected alternatives.**
+- Add the grant to the shared serverless deploy profile: would give unrelated services identity-access table readback.
+- Add `Query`, `Scan`, batch reads, or table wildcards: unnecessary for the live proof, which requires one `GetItem` against the identity-access nonprod table.
+- Add staging or production grants: speculative privilege with no matching e2e-canary lane or live proof requirement.
+
+**Implementation.** Plan: `docs/plans/2026-07-02-e2e-canary-identity-scope-readback-iam-plan.md`. Expected code surfaces: `infiquetra_aws_infra/campps_deploy_roles_stack.py` and `tests/unit/test_campps_deploy_roles_stack.py`.
+
+**Revisit when.** The e2e canary proof runs in staging/production, the readback shape needs a different DynamoDB operation, or a second fixture needs a similar grant and the helper pattern should become a small reusable optional-policy registry.
+
+**Commit.** Planned; implementation pending.
+
+---
+
 ## 2026-06-23
 
 ### Cross-service deploy-role grant for the scope-origination seam proof (tenant-setup nonprod only)

--- a/docs/plans/2026-07-02-e2e-canary-identity-scope-readback-iam-plan.md
+++ b/docs/plans/2026-07-02-e2e-canary-identity-scope-readback-iam-plan.md
@@ -1,0 +1,218 @@
+---
+title: Add e2e-canary nonprod identity-scope readback IAM grant
+type: fix
+status: active
+date: 2026-07-02
+origin: ""
+deepened: 2026-07-02
+---
+
+# Add e2e-canary nonprod identity-scope readback IAM grant
+
+## Summary
+
+Add one optional managed policy to the CAMPPS deploy-role stack for only `campps-e2e-canary` in `nonprod`, attached only to `campps-e2e-canary-nonprod-gha-deploy-role`, granting exactly `dynamodb:GetItem` on `campps-identity-access-nonprod`.
+
+The work is a minimum IAM unblocking change for the `tenant-config-publish-and-scope` live proof. It should not broaden the base deploy profile, staging, production, or unrelated service roles.
+
+---
+
+## Problem Frame
+
+The e2e canary live proof publishes a synthetic tenant/session through `campps-tenant-setup`, then reads back the identity-access projection row at `PK=TENANT#{tenant_id}` and `SK=SCOPE#session#{session_id}`. Current IAM simulation for `arn:aws:iam::477152411873:role/campps-e2e-canary-nonprod-gha-deploy-role` returns `implicitDeny` for `dynamodb:GetItem` on `arn:aws:dynamodb:us-east-1:477152411873:table/campps-identity-access-nonprod`.
+
+The repo already has a comparable pattern for a deploy-gated cross-service proof: `_create_scope_seam_proof_policy` returns `None` unless the service is `tenant-setup` and the target environment is `nonprod`, then attaches a narrow managed policy to that deploy role.
+
+---
+
+## Requirements
+
+R1. `campps-e2e-canary-nonprod-gha-deploy-role` receives a dedicated managed policy for identity scope readback.
+
+R2. The policy grants only `dynamodb:GetItem` on `arn:aws:dynamodb:us-east-1:477152411873:table/campps-identity-access-nonprod`.
+
+R3. The synthesized policy does not include `dynamodb:Query`, `dynamodb:Scan`, wildcard DynamoDB table access, staging resources, or production resources.
+
+R4. No e2e-canary staging or production role/policy is synthesized.
+
+R5. Unrelated service deploy roles do not receive the e2e-canary identity-scope readback policy.
+
+R6. The existing tenant-setup seam-proof grant remains functionally unchanged.
+
+R7. Validation covers unit synthesis, lint/type checks, CDK synth, nonprod workload-stack deploy, and IAM simulation readback.
+
+---
+
+## Key Technical Decisions
+
+KTD1. Use a standalone optional managed-policy helper: mirror `_create_scope_seam_proof_policy` instead of modifying the shared `serverless-api` deploy policy because this grant is for one live proof lane, not a general deploy capability.
+
+KTD2. Gate on both service and environment: require `service_repository.name == "e2e-canary"` and `target_environment == "nonprod"` even though the registry already marks e2e-canary nonprod-only, because the helper should be auditable and testable if registry shape changes.
+
+KTD3. Grant only table-level `dynamodb:GetItem`: use the exact identity-access nonprod table ARN and do not add `Query`, `Scan`, table wildcards, or row-key IAM conditions; the runtime tenant/session keys are synthetic and the acceptance contract is the one required `GetItem` simulation.
+
+KTD4. Pin the managed policy name: use `campps-e2e-canary-nonprod-gha-identity-scope-readback-policy` so the policy is auditable in IAM and unit tests can assert the exact synthesized attachment.
+
+KTD5. Deploy through the CAMPPS workload bootstrap path: changes to `CamppsNonProdDeployRolesStack` require the workload deploy-role stack, not only the management-account foundation pipeline.
+
+---
+
+## High-Level Technical Design
+
+The deploy-role stack already creates a role per in-scope service/environment, attaches the deploy-profile managed policies, then conditionally attaches the tenant-setup seam-proof policy.
+
+```
+CAMPPS_SERVICE_REPOSITORIES
+  -> CamppsDeployRolesStack(target_environment)
+    -> skip services not in environment
+    -> create deploy role
+    -> attach base deploy-profile policies
+    -> attach tenant-setup seam-proof policy when tenant-setup + nonprod
+    -> attach e2e-canary identity readback policy when e2e-canary + nonprod
+```
+
+The new policy should be parallel to the tenant-setup helper, not folded into the base deploy policies. The managed policy name should be `campps-e2e-canary-nonprod-gha-identity-scope-readback-policy`.
+
+---
+
+## Implementation Units
+
+### U1. Add the e2e-canary nonprod readback policy helper
+
+Add the narrow IAM policy without changing shared deploy-profile grants.
+
+**Goal:** Create an optional managed-policy helper in `CamppsDeployRolesStack` and attach it only when the current service is `e2e-canary` and the target environment is `nonprod`.
+
+**Requirements:** R1, R2, R3, R4, R5.
+
+**Dependencies:** None.
+
+**Files:** `infiquetra_aws_infra/campps_deploy_roles_stack.py`; `tests/unit/test_campps_deploy_roles_stack.py`.
+
+**Approach:** Add a method next to `_create_scope_seam_proof_policy` that returns `iam.ManagedPolicy | None`. The method should return `None` for every service/environment combination except `e2e-canary` + `nonprod`, and its non-`None` branch should contain exactly one `iam.PolicyStatement` with `actions=["dynamodb:GetItem"]` and the formatted identity-access nonprod table ARN.
+
+**Patterns to follow:** The existing constructor attaches optional policies after base deploy policies at `infiquetra_aws_infra/campps_deploy_roles_stack.py:62-75`. The tenant-setup seam-proof helper demonstrates the guard-return pattern at `infiquetra_aws_infra/campps_deploy_roles_stack.py:1602-1663`.
+
+**Test scenarios:** Happy path: synthesize only `ServiceRepository(name="e2e-canary", repository="infiquetra/campps-e2e-canary", environments=("nonprod",))` for `nonprod`; assert the managed policy exists, has exactly one statement, grants only `dynamodb:GetItem`, targets only `table/campps-identity-access-nonprod`, and the e2e-canary deploy role includes a `ManagedPolicyArns` reference to that policy.
+
+**Test scenarios:** Real registry higher environments: synthesize `CANONICAL_SERVICE_REPOSITORIES` for `staging` and `production`; assert no e2e-canary role is synthesized and no identity-scope readback policy or higher-environment identity-access table resource appears.
+
+**Test scenarios:** Helper guard: synthesize a test-only `ServiceRepository(name="e2e-canary", repository="infiquetra/campps-e2e-canary", environments=("nonprod", "staging", "production"))` for `staging` and `production`; if those test-only roles are present, assert the identity-scope readback policy is still absent.
+
+**Verification:** The generated CloudFormation contains one new managed policy and one new role attachment in the nonprod e2e-canary template, with no changes to base policy names or permissions boundaries.
+
+### U2. Add regression tests for isolation and existing seam-proof behavior
+
+Prove the new policy is not accidentally generalized.
+
+**Goal:** Extend `tests/unit/test_campps_deploy_roles_stack.py` with positive and negative synthesis coverage for the new grant while preserving the tenant-setup seam-proof tests.
+
+**Requirements:** R3, R4, R5, R6.
+
+**Dependencies:** U1.
+
+**Files:** `tests/unit/test_campps_deploy_roles_stack.py`.
+
+**Approach:** Add an `E2E_CANARY_REPO` fixture constant near the existing `TENANT_SETUP_REPO` seam-proof section. Add policy-name helpers or assertions that search `AWS::IAM::ManagedPolicy` names by exact managed policy name or suffix, matching the existing `find_managed_policy` helper.
+
+**Patterns to follow:** `find_managed_policy` already locates synthesized managed policies by exact name at `tests/unit/test_campps_deploy_roles_stack.py:1106-1114`. Existing e2e-canary tests assert the fixture is nonprod-only and role-gated at `tests/unit/test_campps_deploy_roles_stack.py:258-265` and `tests/unit/test_campps_deploy_roles_stack.py:1160-1200`. The tenant-setup seam-proof tests at `tests/unit/test_campps_deploy_roles_stack.py:1376-1451` provide the positive/negative policy structure.
+
+**Test scenarios:** Happy path: e2e-canary nonprod gets exactly one identity-scope readback policy and the role attachment points at it.
+
+**Test scenarios:** Isolation: synthesize tenant-setup, identity-access, and at least one unrelated serverless service for nonprod; assert none receive or synthesize the e2e-canary readback policy.
+
+**Test scenarios:** Higher environments: synthesize the real canonical registry for staging and production; assert no e2e-canary role or identity-scope readback policy is produced.
+
+**Test scenarios:** Regression: keep the existing tenant-setup seam-proof policy name and its two expected statements unchanged, and assert it does not acquire the e2e-canary readback policy.
+
+**Verification:** `uv run pytest tests/unit/test_campps_deploy_roles_stack.py -q` proves the positive grant, negative environments, unrelated-service isolation, and tenant-setup regression in one focused suite.
+
+### U3. Validate, deploy nonprod, and record operational evidence
+
+Ship only after the synthesized policy passes local gates and live IAM simulation.
+
+**Goal:** Validate the narrow synthesis result, deploy the nonprod workload deploy-role stack, and prove the live role can perform the required `GetItem`.
+
+**Requirements:** R7.
+
+**Dependencies:** U1, U2.
+
+**Files:** `docs/engineering-journal/DECISIONS.md`; `docs/engineering-journal/LEARNINGS.md` only if deployment reveals a durable surprise.
+
+**Approach:** Keep the decision entry tied to the helper, policy name, rejected broad grants, and revisit conditions. Deployment should target `CamppsNonProdDeployRolesStack` from `app_campps_bootstrap.py`; do not rely on the management-account foundation workflow alone.
+
+**Patterns to follow:** `app_campps_bootstrap.py:18-24` defines the nonprod deploy-role stack. The engineering journal notes that workload deploy-role policy changes require the CAMPPS workload deploy-role stack and a live IAM simulation at `docs/engineering-journal/LEARNINGS.md:71-83`.
+
+**Test scenarios:** Integration: after deploy, run IAM simulation for principal `arn:aws:iam::477152411873:role/campps-e2e-canary-nonprod-gha-deploy-role`, action `dynamodb:GetItem`, resource `arn:aws:dynamodb:us-east-1:477152411873:table/campps-identity-access-nonprod`; expected result is `allowed`.
+
+**Test scenarios:** Checklist-only: confirm the required e2e-canary actor-token GitHub/operator environment secret exists before the live workflow is run; do not add the token value or secret wiring to this repo.
+
+**Verification:** Local gates pass, CDK synth succeeds, `CamppsNonProdDeployRolesStack` deploys, and IAM simulation returns `allowed` for the exact required action/resource.
+
+---
+
+## Risks & Dependencies
+
+| risk | impact | mitigation |
+|------|--------|------------|
+| Wrong deployment path | Source merges but the live nonprod role remains denied. | Deploy `CamppsNonProdDeployRolesStack` via the CAMPPS workload bootstrap app and verify with IAM simulation. |
+| Grant accidentally lands in a shared profile | Unrelated services inherit identity-access table readback. | Keep the grant in a guarded optional helper and test unrelated services. |
+| Higher environments receive speculative access | Staging/production deploy roles get unnecessary cross-service read access. | Gate on `target_environment == "nonprod"` and add staging/production negative synthesis tests. |
+
+---
+
+## Verification Gates
+
+Run the narrow checks first, then broaden only after unit synthesis passes.
+
+```bash
+uv run pytest tests/unit/test_campps_deploy_roles_stack.py -q
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy infiquetra_aws_infra tests
+uv run cdk synth --all --quiet
+uv run cdk -a "python app_campps_bootstrap.py" synth --quiet
+```
+
+Deploy the nonprod workload deploy-role stack after the local gates pass.
+
+```bash
+uv run cdk -a "python app_campps_bootstrap.py" deploy \
+  CamppsNonProdDeployRolesStack \
+  --profile campps-nonprod --region us-east-1
+```
+
+After nonprod deployment, run IAM simulation for the live role/action/resource.
+
+```bash
+aws iam simulate-principal-policy \
+  --profile campps-nonprod \
+  --policy-source-arn arn:aws:iam::477152411873:role/campps-e2e-canary-nonprod-gha-deploy-role \
+  --action-names dynamodb:GetItem \
+  --resource-arns arn:aws:dynamodb:us-east-1:477152411873:table/campps-identity-access-nonprod
+```
+
+---
+
+## Scope Boundaries
+
+This plan does not add `Query`, `Scan`, batch reads, write actions, table wildcards, staging grants, production grants, or unrelated service-role grants.
+
+This plan does not run the full `campps-e2e-canary` live workflow; that is a follow-up verification once IAM simulation is allowed and required operator/GitHub environment prerequisites are confirmed.
+
+---
+
+## Sources / Research
+
+| source | evidence |
+|--------|----------|
+| `infiquetra_aws_infra/campps_deploy_roles_stack.py:49-75` | Stack iterates in-scope service repositories and attaches optional managed policies to each deploy role. |
+| `infiquetra_aws_infra/campps_deploy_roles_stack.py:1602-1663` | Tenant-setup seam-proof policy is a guarded helper with nonprod-only cross-service grants. |
+| `infiquetra_aws_infra/campps_service_registry.py:88-98` | `e2e-canary` is explicitly registered as a nonprod-only deploy fixture. |
+| `tests/unit/test_campps_deploy_roles_stack.py:1106-1114` | Unit tests already provide exact managed-policy lookup helpers. |
+| `tests/unit/test_campps_deploy_roles_stack.py:1160-1200` | Existing tests prove e2e-canary role creation is nonprod-only. |
+| `tests/unit/test_campps_deploy_roles_stack.py:1376-1451` | Existing seam-proof tests provide the positive/negative policy-test model. |
+| `cdk.json:1-3` | The default CDK app is `python3 app.py`, so workload deploy-role synth needs an explicit app override. |
+| `docs/ops/04-ci-cd-pipeline.md:194-208` | Workload deploy-role synth/deploy uses `uv run cdk -a "python app_campps_bootstrap.py"` and deploys nonprod first. |
+| `docs/engineering-journal/DECISIONS.md:47-62` | Prior tenant-setup seam-proof decision records the narrow grant pattern and rejected broad grants. |
+| `docs/engineering-journal/LEARNINGS.md:71-83` | Workload deploy-role policy changes require the CAMPPS workload deploy-role stack plus live IAM simulation. |

--- a/docs/reviews/2026-07-02-e2e-canary-identity-scope-readback-iam-plan-review.md
+++ b/docs/reviews/2026-07-02-e2e-canary-identity-scope-readback-iam-plan-review.md
@@ -1,0 +1,42 @@
+# Doc Review: e2e-canary identity-scope readback IAM plan
+
+The reviewed plan is ready to drive implementation after three safe in-place fixes.
+
+| field | value |
+|-------|-------|
+| target path | `docs/plans/2026-07-02-e2e-canary-identity-scope-readback-iam-plan.md` |
+| reviewed revision | working tree on `main` |
+| blocked status | not blocked |
+| review artifact path | `docs/reviews/2026-07-02-e2e-canary-identity-scope-readback-iam-plan-review.md` |
+| linked plan | `docs/plans/2026-07-02-e2e-canary-identity-scope-readback-iam-plan.md` |
+
+## Applied Fixes
+
+The fixes remove ambiguity that would have forced `/work` to invent test or deployment details.
+
+| priority | status | fix |
+|----------|--------|-----|
+| P2 | fixed | Split the higher-environment test guidance into real-registry absence and test-only helper-guard scenarios, so implementation does not accidentally synthesize staging/production canary roles as part of the acceptance path. |
+| P2 | fixed | Pinned the managed policy name to `campps-e2e-canary-nonprod-gha-identity-scope-readback-policy`, matching the plan's naming intent and making role attachment tests exact. |
+| P2 | fixed | Added the explicit `uv run cdk -a "python app_campps_bootstrap.py" deploy CamppsNonProdDeployRolesStack --profile campps-nonprod --region us-east-1` deployment gate before IAM simulation. |
+
+## Readiness Summary
+
+The plan is ready for `/work`.
+
+It has stable requirements, KTDs, implementation units, test scenarios, explicit scope boundaries, and a deploy-to-nonprod verification path. The remaining implementation work is bounded to `infiquetra_aws_infra/campps_deploy_roles_stack.py` and `tests/unit/test_campps_deploy_roles_stack.py`, with journal follow-through already called out.
+
+## Remaining Findings By Priority
+
+No blocking findings remain.
+
+| priority | status | finding |
+|----------|--------|---------|
+| P0 | none | No unsafe or materially wrong execution path found. |
+| P1 | none | No missing core requirement, gate, or decision found after fixes. |
+| P2 | none | No meaningful implementation ambiguity remains after fixes. |
+| P3 | none | No polish-only findings worth carrying. |
+
+## Residual Risk
+
+The IAM simulation result and actor-token environment prerequisite remain live-environment evidence, not something this document review can prove. The plan correctly keeps those as verification/checklist gates rather than assuming they are already satisfied.

--- a/docs/work-sessions/2026-07-02-e2e-canary-identity-scope-readback-iam.md
+++ b/docs/work-sessions/2026-07-02-e2e-canary-identity-scope-readback-iam.md
@@ -1,0 +1,39 @@
+# Work Session: e2e-canary identity-scope readback IAM grant
+
+Implemented the reviewed nonprod IAM grant for the e2e canary identity-scope live proof.
+
+## Summary
+
+Built U1 and U2 from `docs/plans/2026-07-02-e2e-canary-identity-scope-readback-iam-plan.md`. The stack now attaches a dedicated managed policy only to `campps-e2e-canary` in `nonprod`, granting one action, `dynamodb:GetItem`, on `campps-identity-access-nonprod`.
+
+## Built
+
+| unit | status | evidence |
+|------|--------|----------|
+| U1 | complete | Added `_create_e2e_canary_identity_scope_readback_policy` and attached its optional policy in `infiquetra_aws_infra/campps_deploy_roles_stack.py`. |
+| U2 | complete | Added exact positive and negative synthesis tests in `tests/unit/test_campps_deploy_roles_stack.py`, including role attachment, action/resource scope, higher-environment absence, helper guard, unrelated services, and tenant-setup regression. |
+| U3 | partial | Local validation and workload synth passed. Nonprod deploy and live IAM simulation are intentionally left for the deploy phase. |
+
+## Checks Run
+
+| check | result |
+|-------|--------|
+| `uv run pytest tests/unit/test_campps_deploy_roles_stack.py -q` | passed, 54 tests |
+| `uv run ruff check .` | passed |
+| `uv run ruff format --check .` | passed |
+| `uv run mypy infiquetra_aws_infra tests` | passed |
+| `uv run cdk synth --all --quiet` | passed |
+| `uv run cdk -a "python app_campps_bootstrap.py" synth --quiet` | passed |
+| `rg "identity-scope-readback|IdentityScopeReadback" cdk.out/CamppsStagingDeployRolesStack.template.json cdk.out/CamppsProductionDeployRolesStack.template.json` | no matches |
+
+## Review Gate
+
+Inline code-review gate found no blocking findings before PR-ready handoff.
+
+Scope check: CLEAN. The diff implements the planned e2e-canary nonprod readback IAM grant, test coverage, plan/review artifacts, and journal update.
+
+Plan completion: U1 DONE, U2 DONE, U3 PARTIAL. The remaining U3 steps are external deployment and live IAM simulation, which belong after merge/deploy confirmation.
+
+## Next Step
+
+Open a PR from `fix/e2e-canary-identity-scope-readback`, then route post-merge to nonprod deploy for `CamppsNonProdDeployRolesStack` and the live IAM simulation.

--- a/docs/work-sessions/2026-07-02-e2e-canary-identity-scope-readback-iam.md
+++ b/docs/work-sessions/2026-07-02-e2e-canary-identity-scope-readback-iam.md
@@ -1,10 +1,10 @@
 # Work Session: e2e-canary identity-scope readback IAM grant
 
-Implemented the reviewed nonprod IAM grant for the e2e canary identity-scope live proof.
+Implemented and deployed the reviewed nonprod IAM grant for the e2e canary identity-scope live proof.
 
 ## Summary
 
-Built U1 and U2 from `docs/plans/2026-07-02-e2e-canary-identity-scope-readback-iam-plan.md`. The stack now attaches a dedicated managed policy only to `campps-e2e-canary` in `nonprod`, granting one action, `dynamodb:GetItem`, on `campps-identity-access-nonprod`.
+Built U1, U2, and U3 from `docs/plans/2026-07-02-e2e-canary-identity-scope-readback-iam-plan.md`. The stack now attaches a dedicated managed policy only to `campps-e2e-canary` in `nonprod`, granting one action, `dynamodb:GetItem`, on `campps-identity-access-nonprod`.
 
 ## Built
 
@@ -12,7 +12,7 @@ Built U1 and U2 from `docs/plans/2026-07-02-e2e-canary-identity-scope-readback-i
 |------|--------|----------|
 | U1 | complete | Added `_create_e2e_canary_identity_scope_readback_policy` and attached its optional policy in `infiquetra_aws_infra/campps_deploy_roles_stack.py`. |
 | U2 | complete | Added exact positive and negative synthesis tests in `tests/unit/test_campps_deploy_roles_stack.py`, including role attachment, action/resource scope, higher-environment absence, helper guard, unrelated services, and tenant-setup regression. |
-| U3 | partial | Local validation and workload synth passed. Nonprod deploy and live IAM simulation are intentionally left for the deploy phase. |
+| U3 | complete | Deployed `CamppsNonProdDeployRolesStack`; CloudFormation reported `UPDATE_COMPLETE`, created `E2eCanaryIdentityScopeReadbackPolicy`, updated `E2eCanaryDeployRole`, and live IAM simulation returned `allowed` for the required `dynamodb:GetItem`. |
 
 ## Checks Run
 
@@ -25,6 +25,9 @@ Built U1 and U2 from `docs/plans/2026-07-02-e2e-canary-identity-scope-readback-i
 | `uv run cdk synth --all --quiet` | passed |
 | `uv run cdk -a "python app_campps_bootstrap.py" synth --quiet` | passed |
 | `rg "identity-scope-readback|IdentityScopeReadback" cdk.out/CamppsStagingDeployRolesStack.template.json cdk.out/CamppsProductionDeployRolesStack.template.json` | no matches |
+| `uv run cdk -a "python app_campps_bootstrap.py" deploy CamppsNonProdDeployRolesStack --region us-east-1 --require-approval never` | passed, `UPDATE_COMPLETE` |
+| `aws iam simulate-principal-policy --policy-source-arn arn:aws:iam::477152411873:role/campps-e2e-canary-nonprod-gha-deploy-role --action-names dynamodb:GetItem --resource-arns arn:aws:dynamodb:us-east-1:477152411873:table/campps-identity-access-nonprod` | `allowed` |
+| GitHub PR checks for PR #142 | passed, 4 checks |
 
 ## Review Gate
 
@@ -32,8 +35,8 @@ Inline code-review gate found no blocking findings before PR-ready handoff.
 
 Scope check: CLEAN. The diff implements the planned e2e-canary nonprod readback IAM grant, test coverage, plan/review artifacts, and journal update.
 
-Plan completion: U1 DONE, U2 DONE, U3 PARTIAL. The remaining U3 steps are external deployment and live IAM simulation, which belong after merge/deploy confirmation.
+Plan completion: U1 DONE, U2 DONE, U3 DONE.
 
 ## Next Step
 
-Open a PR from `fix/e2e-canary-identity-scope-readback`, then route post-merge to nonprod deploy for `CamppsNonProdDeployRolesStack` and the live IAM simulation.
+Merge PR #142 once the normal review/branch policy is satisfied, then clean up the feature branch after `main` contains the change.

--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -74,6 +74,15 @@ class CamppsDeployRolesStack(Stack):
             if seam_proof_policy is not None:
                 deploy_role.add_managed_policy(seam_proof_policy)
 
+            identity_scope_readback_policy = (
+                self._create_e2e_canary_identity_scope_readback_policy(
+                    service_repository=service_repository,
+                    target_environment=target_environment,
+                )
+            )
+            if identity_scope_readback_policy is not None:
+                deploy_role.add_managed_policy(identity_scope_readback_policy)
+
             CfnOutput(
                 self,
                 f"{self._logical_id_prefix(service_repository.name)}DeployRoleArn",
@@ -1649,6 +1658,45 @@ class CamppsDeployRolesStack(Stack):
                 ),
                 iam.PolicyStatement(
                     sid="ScopeSeamConsumerReadback",
+                    actions=["dynamodb:GetItem"],
+                    resources=[
+                        self.format_arn(
+                            service="dynamodb",
+                            resource="table",
+                            resource_name=f"campps-identity-access-{target_environment}",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                ),
+            ],
+        )
+
+    def _create_e2e_canary_identity_scope_readback_policy(
+        self,
+        *,
+        service_repository: ServiceRepository,
+        target_environment: DeployEnvironment,
+    ) -> iam.ManagedPolicy | None:
+        """Nonprod-only readback grant for the e2e canary identity-scope proof."""
+        if service_repository.name != "e2e-canary" or target_environment != "nonprod":
+            return None
+        return iam.ManagedPolicy(
+            self,
+            (
+                f"{self._logical_id_prefix(service_repository.name)}"
+                "IdentityScopeReadbackPolicy"
+            ),
+            managed_policy_name=(
+                f"campps-{service_repository.name}-{target_environment}"
+                "-gha-identity-scope-readback-policy"
+            ),
+            description=(
+                "Identity scope readback grant for "
+                f"{service_repository.repository} {target_environment}"
+            ),
+            statements=[
+                iam.PolicyStatement(
+                    sid="IdentityScopeReadback",
                     actions=["dynamodb:GetItem"],
                     resources=[
                         self.format_arn(

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -1104,14 +1104,30 @@ NEW_BACKEND_SERVICES: tuple[ServiceRepository, ...] = tuple(
 
 
 def find_managed_policy(template: Template, policy_name: str) -> dict[str, Any]:
+    return find_managed_policy_with_logical_id(template, policy_name)[1]
+
+
+def find_managed_policy_with_logical_id(
+    template: Template, policy_name: str
+) -> tuple[str, dict[str, Any]]:
     policies = template.find_resources("AWS::IAM::ManagedPolicy")
     matching = [
-        policy
-        for policy in policies.values()
+        (logical_id, policy)
+        for logical_id, policy in policies.items()
         if policy.get("Properties", {}).get("ManagedPolicyName") == policy_name
     ]
     assert len(matching) == 1, (policy_name, list(policies))
-    return dict(matching[0])
+    logical_id, policy = matching[0]
+    return logical_id, dict(policy)
+
+
+def managed_policy_names(template: Template) -> set[str]:
+    names: set[str] = set()
+    for policy in template.find_resources("AWS::IAM::ManagedPolicy").values():
+        name = policy.get("Properties", {}).get("ManagedPolicyName")
+        if isinstance(name, str):
+            names.add(name)
+    return names
 
 
 def test_every_serverless_backend_mints_role_and_boundary_per_environment() -> None:
@@ -1370,7 +1386,29 @@ TENANT_SETUP_REPO = ServiceRepository(
     repository="infiquetra/campps-tenant-setup",
 )
 
+E2E_CANARY_REPO = ServiceRepository(
+    name="e2e-canary",
+    repository="infiquetra/campps-e2e-canary",
+    environments=("nonprod",),
+)
+
+E2E_CANARY_ALL_ENVIRONMENTS_REPO = ServiceRepository(
+    name="e2e-canary",
+    repository="infiquetra/campps-e2e-canary",
+)
+
 SEAM_PROOF_POLICY_NAME = "campps-tenant-setup-nonprod-gha-seam-proof-policy"
+IDENTITY_SCOPE_READBACK_POLICY_NAME = (
+    "campps-e2e-canary-nonprod-gha-identity-scope-readback-policy"
+)
+IDENTITY_SCOPE_READBACK_POLICY_SUFFIX = "-gha-identity-scope-readback-policy"
+
+
+def assert_no_identity_scope_readback_policy(template: Template) -> None:
+    policy_names = managed_policy_names(template)
+    assert not any(
+        name.endswith(IDENTITY_SCOPE_READBACK_POLICY_SUFFIX) for name in policy_names
+    ), f"Unexpected identity-scope readback policy: {policy_names}"
 
 
 def test_tenant_setup_nonprod_deploy_role_has_seam_proof_policy() -> None:
@@ -1386,6 +1424,10 @@ def test_tenant_setup_nonprod_deploy_role_has_seam_proof_policy() -> None:
 
     statements_by_sid = {
         stmt["Sid"]: stmt for stmt in document["Statement"] if "Sid" in stmt
+    }
+    assert set(statements_by_sid) == {
+        "ScopeSeamProducerEmit",
+        "ScopeSeamConsumerReadback",
     }
 
     # ScopeSeamProducerEmit: events:PutEvents on the platform bus.
@@ -1449,3 +1491,98 @@ def test_identity_access_nonprod_has_no_seam_proof_policy() -> None:
     assert not any(
         name is not None and "gha-seam-proof-policy" in name for name in policy_names
     ), f"Unexpected seam-proof policy for identity-access: {policy_names}"
+
+
+# --- e2e-canary identity-scope readback grant -------------------------------
+#
+# The nonprod deploy role for e2e-canary needs a single cross-service permission
+# to run tenant-config-publish-and-scope:
+#   - dynamodb:GetItem on identity-access's table (campps-identity-access-nonprod)
+#
+# The grant is scoped to e2e-canary + nonprod only.
+
+
+def test_e2e_canary_nonprod_deploy_role_has_identity_scope_readback_policy() -> None:
+    """Positive: e2e-canary nonprod role can read exactly one identity table."""
+    template = synth_template_for_repositories(
+        E2E_CANARY_REPO, target_environment="nonprod"
+    )
+
+    policy_logical_id, policy = find_managed_policy_with_logical_id(
+        template, IDENTITY_SCOPE_READBACK_POLICY_NAME
+    )
+    document = policy["Properties"]["PolicyDocument"]
+    statements = document["Statement"]
+
+    assert len(statements) == 1, statements
+    statement = statements[0]
+    assert statement["Sid"] == "IdentityScopeReadback"
+    assert set(normalize_actions(statement["Action"])) == {"dynamodb:GetItem"}
+
+    resources = str(statement["Resource"])
+    assert "table/campps-identity-access-nonprod" in resources, resources
+    assert "campps-identity-access-staging" not in resources
+    assert "campps-identity-access-production" not in resources
+    assert "*" not in resources
+
+    role = find_deploy_role(template, E2E_CANARY_REPO.role_name("nonprod"))
+    managed_policy_arns = role["Properties"]["ManagedPolicyArns"]
+    assert {"Ref": policy_logical_id} in managed_policy_arns
+
+
+def test_e2e_canary_real_registry_has_no_higher_environment_readback_policy() -> None:
+    """Negative: the real registry mints no e2e-canary higher-env role or policy."""
+    higher_envs: tuple[DeployEnvironment, ...] = ("staging", "production")
+    for environment in higher_envs:
+        template = synth_template_for_repositories(
+            *CANONICAL_SERVICE_REPOSITORIES,
+            target_environment=environment,
+        )
+        role_names = {
+            role.get("Properties", {}).get("RoleName")
+            for role in template.find_resources("AWS::IAM::Role").values()
+        }
+
+        assert E2E_CANARY_REPO.role_name(environment) not in role_names, (
+            environment,
+            sorted(name for name in role_names if name),
+        )
+        assert_no_identity_scope_readback_policy(template)
+
+
+def test_e2e_canary_higher_environment_helper_guard_returns_no_policy() -> None:
+    """Negative: even an all-env canary test fixture gets no higher-env policy."""
+    higher_envs: tuple[DeployEnvironment, ...] = ("staging", "production")
+    for environment in higher_envs:
+        template = synth_template_for_repositories(
+            E2E_CANARY_ALL_ENVIRONMENTS_REPO,
+            target_environment=environment,
+        )
+
+        template.has_resource_properties(
+            "AWS::IAM::Role",
+            {"RoleName": E2E_CANARY_ALL_ENVIRONMENTS_REPO.role_name(environment)},
+        )
+        assert_no_identity_scope_readback_policy(template)
+
+
+def test_unrelated_nonprod_services_have_no_identity_scope_readback_policy() -> None:
+    """Negative: the e2e canary readback grant does not leak to other services."""
+    unrelated_services = (
+        TENANT_SETUP_REPO,
+        ServiceRepository(
+            name="identity-access",
+            repository="infiquetra/campps-identity-access",
+        ),
+        ServiceRepository(
+            name="registration",
+            repository="infiquetra/campps-registration",
+        ),
+    )
+
+    for service_repository in unrelated_services:
+        template = synth_template_for_repositories(
+            service_repository,
+            target_environment="nonprod",
+        )
+        assert_no_identity_scope_readback_policy(template)


### PR DESCRIPTION
## Summary
- add a dedicated nonprod-only managed policy for `campps-e2e-canary-nonprod-gha-deploy-role`
- grant only `dynamodb:GetItem` on `campps-identity-access-nonprod`
- add synthesis tests for positive attachment, higher-env absence, helper guard, unrelated services, and tenant-setup regression
- record the plan, doc-review, journal decision, and work-session evidence

## Plan / Review
- Plan: `docs/plans/2026-07-02-e2e-canary-identity-scope-readback-iam-plan.md`
- Doc review: `docs/reviews/2026-07-02-e2e-canary-identity-scope-readback-iam-plan-review.md`
- Work session: `docs/work-sessions/2026-07-02-e2e-canary-identity-scope-readback-iam.md`

## Validation
- [x] `uv run pytest tests/unit/test_campps_deploy_roles_stack.py -q` — 54 passed
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy infiquetra_aws_infra tests`
- [x] `uv run cdk synth --all --quiet`
- [x] `uv run cdk -a "python app_campps_bootstrap.py" synth --quiet`
- [x] template readback: identity-scope policy appears in nonprod only; no staging/production matches for `identity-scope-readback|IdentityScopeReadback`
- [x] inline code-review gate: no blocking findings, reviewed at `0fb701a`, stale count `0`

## Deploy Follow-Up
After merge/deploy, verify live IAM with:

```bash
aws iam simulate-principal-policy \
  --profile campps-nonprod \
  --policy-source-arn arn:aws:iam::477152411873:role/campps-e2e-canary-nonprod-gha-deploy-role \
  --action-names dynamodb:GetItem \
  --resource-arns arn:aws:dynamodb:us-east-1:477152411873:table/campps-identity-access-nonprod
```
