### PR TITLE
feat(iam): add e2e live proof role

### DIFF
--- a/docs/code-reviews/2026-07-11-e2e-live-proof-role-code-review.md
+++ b/docs/code-reviews/2026-07-11-e2e-live-proof-role-code-review.md
@@ -1,0 +1,74 @@
+---
+title: E2E Live-Proof Role Code Review
+date: 2026-07-11
+target_repository: infiquetra/infiquetra-aws-infra
+target_branch: feat/e2e-live-proof-role
+base_revision: 2dfb3f4
+reviewed_revision: e739fd4
+verified_subject_sha256: 176bb5a5d8b41e5fbe12cf74817f298ecdaa332f486d8148ee61a0719d125757
+blocked: false
+---
+
+# E2E Live-Proof Role Code Review
+
+## Review Result
+
+The U7 infrastructure source is safe to enter the PR loop. No P0, P1, P2, or
+P3 finding survived the full review and validator gate.
+
+| field | value |
+| --- | --- |
+| plan | `campps-e2e-canary/docs/plans/2026-07-11-e2e-live-proof-infra-plan.md` |
+| issue | `infiquetra/campps-e2e-canary#4` |
+| work session | `docs/work-sessions/2026-07-11-e2e-live-proof-role.md` |
+| reviewed SHA | `e739fd4` |
+| verified subject | `176bb5a5d8b41e5fbe12cf74817f298ecdaa332f486d8148ee61a0719d125757` |
+| blocked | false |
+| findings | none |
+
+## Scope Check
+
+**CLEAN.** `2dfb3f4..e739fd4` changes only the deploy-role stack, its focused
+assertions, and the infrastructure decision. It does not change the existing
+deploy role, deploy policy, service registry, workload app, deployment
+workflow, or higher-environment resources. The unrelated untracked
+`docs/FULL_REPO_CODE_REVIEW.md` is outside commit and review attribution.
+
+## Built vs Planned
+
+| requirement | state | evidence |
+| --- | --- | --- |
+| R1: separate one-hour exact-subject role | DONE | Synth pins the role name, 3600-second session, OIDC audience, and exact nonprod Environment subject. |
+| R2: exactly two runtime reads | DONE | One policy contains only canonical WorkOS `GetSecretValue` and exact-table `GetItem`. |
+| R3: no deploy-role or higher-environment widening | DONE | Attachment-isolation, unrelated-service, staging, and production assertions pass. |
+| R4: positive and negative source proof | DONE | Focused assertions cover actions, resources, suffix width, no KMS/write/query/scan, stable synth, and all environment templates. |
+| R5: deployment prerequisites and diff | DONE | GitHub controls and default-key secret inventory were read back; the credentialed target-stack diff is additive only. |
+| R6: post-deploy readback | UNVERIFIABLE | Correctly deferred until the merged source is explicitly deployed to nonprod. |
+
+**SOURCE COMPLETION:** 5 DONE, 1 UNVERIFIABLE, 0 PARTIAL, 0 NOT-DONE, 0
+CHANGED.
+
+## Checks
+
+- Focused deploy-role module: 60 tests passed.
+- Full suite: 76 tests passed.
+- Ruff check and format, strict mypy, Bandit, and `git diff --check` passed.
+- Explicit workload bootstrap synth passed for nonprod, staging, and production.
+- Template readback found one nonprod live-proof role/policy/output and none in
+  staging or production.
+- Credentialed `CamppsNonProdDeployRolesStack` diff contains two additive IAM
+  resources and one output, with no modify or delete operation.
+- Verified Workflows passed with thirteen selected roles, four required
+  command-backed validators, no blockers, and no warnings.
+
+## Residual Risk
+
+This review proves source and the pre-deploy change set, not deployed AWS
+state. Merge does not deploy `app_campps_bootstrap.py`. CloudFormation status,
+role trust, attached policy, positive/negative IAM simulation, unchanged deploy
+role, and final Environment role-ARN wiring remain explicit post-merge gates.
+
+> Verdict: PROCEED TO PR GATE. No unresolved P0/P1 finding and the review is
+> fresh for `e739fd4`.
+
+Review complete

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -25,6 +25,42 @@
 
 ---
 
+## 2026-07-11
+
+### Give the protected nonprod E2E proof its own two-read role
+
+**Decision.** Create a dedicated one-hour GitHub OIDC role for
+`campps-e2e-canary`'s protected `nonprod` Environment. Its single managed policy
+permits only `secretsmanager:GetSecretValue` on the canonical WorkOS API-key
+secret's exact six-character generated-suffix pattern and `dynamodb:GetItem` on
+the exact Identity Access nonprod scope table.
+
+**Rejected alternatives.**
+- Add the provider secret to the existing deploy role: rejected because the
+  live proof needs no CloudFormation, IAM, CDK, or application deployment
+  authority.
+- Reuse the existing identity-scope readback policy: rejected because it is
+  attached to the broad deploy role and cannot establish a two-read runtime
+  boundary.
+- Add `kms:Decrypt`: rejected because live inventory confirms the secret uses
+  the default Secrets Manager key. A customer-managed key would require
+  re-planning instead of widening this role.
+- Create staging or production equivalents: rejected because no corresponding
+  protected live-proof lane exists.
+
+**Implementation.**
+`infiquetra_aws_infra/campps_deploy_roles_stack.py` creates the guarded role,
+policy, and `CamppsE2eCanaryLiveProofRoleArn` output. Focused assertions in
+`tests/unit/test_campps_deploy_roles_stack.py` pin trust, session length,
+actions, resources, attachment isolation, environment/repository guards, and
+stable synthesis.
+
+**Revisit when.** The live proof moves to another environment, the canonical
+secret uses a customer-managed key, the proof requires an additional AWS API,
+or GitHub supports an independently reviewed private-repository Environment.
+
+**Commit.** Pending on branch `feat/e2e-live-proof-role`.
+
 ## 2026-07-05
 
 ### Parent-zone ACME access is scoped to one webhook TXT record

--- a/docs/work-sessions/2026-07-11-e2e-live-proof-role.md
+++ b/docs/work-sessions/2026-07-11-e2e-live-proof-role.md
@@ -1,0 +1,47 @@
+# Work Session: E2E live-proof role
+
+## Scope
+
+Implemented the `campps-e2e-canary#4` U7 source slice from the canonical
+`2026-07-11-e2e-live-proof-infra-plan.md` on
+`feat/e2e-live-proof-role`.
+
+## Completed
+
+- Added `campps-e2e-canary-nonprod-gha-live-proof-role` with a one-hour session
+  and exact GitHub OIDC audience and nonprod Environment subject.
+- Added one managed policy containing only the canonical WorkOS API-key
+  `secretsmanager:GetSecretValue` and Identity Access scope-table
+  `dynamodb:GetItem` reads.
+- Kept the existing e2e canary deploy role and identity-scope readback policy
+  unchanged.
+- Added exhaustive positive, negative, attachment-isolation,
+  higher-environment, unrelated-service, exact suffix-width, and stable-synth
+  assertions.
+- Recorded the least-privilege decision in the engineering journal.
+- Confirmed the canonical secret inventory uses the default Secrets Manager
+  key and the GitHub repository/Environment/operator prerequisites remain in
+  force.
+
+## Verification
+
+- Focused deploy-role module: 60 passed.
+- Full suite: 76 passed.
+- Ruff check/format, strict mypy, Bandit, and `git diff --check`: passed.
+- Explicit `app_campps_bootstrap.py` synth: passed for all three environments.
+- Synth inspection: exactly one nonprod role/policy/output; none in staging or
+  production.
+- Credentialed nonprod target-stack diff: two additive IAM resources and one
+  output; no modify/delete.
+- Verified Workflows: passed at subject digest
+  `176bb5a5d8b41e5fbe12cf74817f298ecdaa332f486d8148ee61a0719d125757`
+  with no blockers or warnings.
+- Programmatic code review: no findings at source commit `e739fd4`.
+
+## Next Step
+
+Open and merge the infrastructure PR after required CI. Then rerun the
+credentialed target-stack diff from merged `main`, deploy only
+`CamppsNonProdDeployRolesStack`, and perform the planned CloudFormation, IAM,
+inventory, policy-simulation, unchanged-deploy-role, and Environment-variable
+readbacks before U8.

--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -83,6 +83,22 @@ class CamppsDeployRolesStack(Stack):
             if identity_scope_readback_policy is not None:
                 deploy_role.add_managed_policy(identity_scope_readback_policy)
 
+            live_proof_role = self._create_e2e_canary_live_proof_role(
+                oidc_provider=oidc_provider,
+                service_repository=service_repository,
+                target_environment=target_environment,
+            )
+            if live_proof_role is not None:
+                CfnOutput(
+                    self,
+                    "CamppsE2eCanaryLiveProofRoleArn",
+                    value=live_proof_role.role_arn,
+                    description=(
+                        "Nonprod live-proof role ARN for "
+                        f"{service_repository.repository}"
+                    ),
+                )
+
             CfnOutput(
                 self,
                 f"{self._logical_id_prefix(service_repository.name)}DeployRoleArn",
@@ -1709,6 +1725,78 @@ class CamppsDeployRolesStack(Stack):
                 ),
             ],
         )
+
+    def _create_e2e_canary_live_proof_role(
+        self,
+        *,
+        oidc_provider: iam.CfnOIDCProvider,
+        service_repository: ServiceRepository,
+        target_environment: DeployEnvironment,
+    ) -> iam.Role | None:
+        """Create the two-read nonprod role used by the protected live proof."""
+        if service_repository.name != "e2e-canary" or target_environment != "nonprod":
+            return None
+
+        role = iam.Role(
+            self,
+            "E2eCanaryLiveProofRole",
+            role_name="campps-e2e-canary-nonprod-gha-live-proof-role",
+            assumed_by=iam.FederatedPrincipal(
+                federated=oidc_provider.attr_arn,
+                conditions={
+                    "StringEquals": {
+                        f"{GITHUB_OIDC_HOST}:aud": GITHUB_OIDC_AUDIENCE,
+                        f"{GITHUB_OIDC_HOST}:sub": (
+                            "repo:infiquetra/campps-e2e-canary:environment:nonprod"
+                        ),
+                    }
+                },
+                assume_role_action="sts:AssumeRoleWithWebIdentity",
+            ),
+            max_session_duration=Duration.hours(1),
+            description=(
+                "Read-only credential and identity-scope access for the protected "
+                "campps-e2e-canary nonprod live proof"
+            ),
+        )
+        policy = iam.ManagedPolicy(
+            self,
+            "E2eCanaryLiveProofPolicy",
+            managed_policy_name="campps-e2e-canary-nonprod-gha-live-proof-policy",
+            description=(
+                "Two-read policy for the protected campps-e2e-canary nonprod live proof"
+            ),
+            statements=[
+                iam.PolicyStatement(
+                    sid="WorkOsProviderSecretRead",
+                    actions=["secretsmanager:GetSecretValue"],
+                    resources=[
+                        self.format_arn(
+                            service="secretsmanager",
+                            resource="secret",
+                            resource_name=(
+                                "campps/identity-access/nonprod/workos/api-key-??????"
+                            ),
+                            arn_format=ArnFormat.COLON_RESOURCE_NAME,
+                        )
+                    ],
+                ),
+                iam.PolicyStatement(
+                    sid="IdentityScopeReadback",
+                    actions=["dynamodb:GetItem"],
+                    resources=[
+                        self.format_arn(
+                            service="dynamodb",
+                            resource="table",
+                            resource_name="campps-identity-access-nonprod",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                ),
+            ],
+        )
+        role.add_managed_policy(policy)
+        return role
 
     @staticmethod
     def _logical_id_prefix(service_name: str) -> str:

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -2,6 +2,7 @@
 
 import json
 from collections.abc import Iterable
+from fnmatch import fnmatchcase
 from typing import Any
 
 import pytest
@@ -1402,6 +1403,9 @@ IDENTITY_SCOPE_READBACK_POLICY_NAME = (
     "campps-e2e-canary-nonprod-gha-identity-scope-readback-policy"
 )
 IDENTITY_SCOPE_READBACK_POLICY_SUFFIX = "-gha-identity-scope-readback-policy"
+LIVE_PROOF_ROLE_NAME = "campps-e2e-canary-nonprod-gha-live-proof-role"
+LIVE_PROOF_POLICY_NAME = "campps-e2e-canary-nonprod-gha-live-proof-policy"
+LIVE_PROOF_POLICY_SUFFIX = "-gha-live-proof-policy"
 
 
 def assert_no_identity_scope_readback_policy(template: Template) -> None:
@@ -1409,6 +1413,21 @@ def assert_no_identity_scope_readback_policy(template: Template) -> None:
     assert not any(
         name.endswith(IDENTITY_SCOPE_READBACK_POLICY_SUFFIX) for name in policy_names
     ), f"Unexpected identity-scope readback policy: {policy_names}"
+
+
+def assert_no_live_proof_resources(template: Template) -> None:
+    role_names = {
+        role.get("Properties", {}).get("RoleName")
+        for role in template.find_resources("AWS::IAM::Role").values()
+    }
+    policy_names = managed_policy_names(template)
+    outputs = template.to_json().get("Outputs", {})
+
+    assert LIVE_PROOF_ROLE_NAME not in role_names, role_names
+    assert not any(name.endswith(LIVE_PROOF_POLICY_SUFFIX) for name in policy_names), (
+        policy_names
+    )
+    assert "CamppsE2eCanaryLiveProofRoleArn" not in outputs, outputs
 
 
 def test_tenant_setup_nonprod_deploy_role_has_seam_proof_policy() -> None:
@@ -1586,3 +1605,167 @@ def test_unrelated_nonprod_services_have_no_identity_scope_readback_policy() -> 
             target_environment="nonprod",
         )
         assert_no_identity_scope_readback_policy(template)
+
+
+# --- e2e-canary dedicated live-proof role ----------------------------------
+
+
+def test_e2e_canary_nonprod_has_dedicated_two_read_live_proof_role() -> None:
+    template = synth_template_for_repositories(
+        E2E_CANARY_REPO, target_environment="nonprod"
+    )
+
+    policy_logical_id, policy = find_managed_policy_with_logical_id(
+        template, LIVE_PROOF_POLICY_NAME
+    )
+    statements = policy["Properties"]["PolicyDocument"]["Statement"]
+    statements_by_sid = {statement["Sid"]: statement for statement in statements}
+
+    assert set(statements_by_sid) == {
+        "WorkOsProviderSecretRead",
+        "IdentityScopeReadback",
+    }
+    assert set(
+        normalize_actions(statements_by_sid["WorkOsProviderSecretRead"]["Action"])
+    ) == {"secretsmanager:GetSecretValue"}
+    secret_resource = str(statements_by_sid["WorkOsProviderSecretRead"]["Resource"])
+    assert (
+        "secretsmanager:us-east-1:477152411873:secret:"
+        "campps/identity-access/nonprod/workos/api-key-??????"
+    ) in secret_resource
+    assert set(
+        normalize_actions(statements_by_sid["IdentityScopeReadback"]["Action"])
+    ) == {"dynamodb:GetItem"}
+    scope_resource = str(statements_by_sid["IdentityScopeReadback"]["Resource"])
+    assert (
+        "dynamodb:us-east-1:477152411873:table/campps-identity-access-nonprod"
+    ) in scope_resource
+
+    role = find_deploy_role(template, LIVE_PROOF_ROLE_NAME)
+    assert role["Properties"]["MaxSessionDuration"] == 3600
+    assert role["Properties"]["ManagedPolicyArns"] == [{"Ref": policy_logical_id}]
+
+    trust = get_assume_role_statement(role)
+    assert trust["Condition"]["StringEquals"] == {
+        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+        "token.actions.githubusercontent.com:sub": (
+            "repo:infiquetra/campps-e2e-canary:environment:nonprod"
+        ),
+    }
+
+    outputs = template.to_json()["Outputs"]
+    output_get_att = outputs["CamppsE2eCanaryLiveProofRoleArn"]["Value"]["Fn::GetAtt"]
+    assert output_get_att[0].startswith("E2eCanaryLiveProofRole")
+    assert output_get_att[1] == "Arn"
+
+
+def test_live_proof_policy_has_no_widened_actions_or_resources() -> None:
+    template = synth_template_for_repositories(
+        E2E_CANARY_REPO, target_environment="nonprod"
+    )
+    _, policy = find_managed_policy_with_logical_id(template, LIVE_PROOF_POLICY_NAME)
+    statements = policy["Properties"]["PolicyDocument"]["Statement"]
+
+    actions = {
+        action
+        for statement in statements
+        for action in normalize_actions(statement["Action"])
+    }
+    resources = {
+        resource
+        for statement in statements
+        for resource in normalize_resources(statement["Resource"])
+    }
+
+    assert actions == {"secretsmanager:GetSecretValue", "dynamodb:GetItem"}
+    assert "*" not in actions
+    assert "*" not in resources
+    assert not any(action.startswith("kms:") for action in actions)
+    assert not any(
+        action in {"dynamodb:Query", "dynamodb:Scan", "dynamodb:PutItem"}
+        for action in actions
+    )
+    assert not any(
+        "staging" in resource or "production" in resource for resource in resources
+    )
+
+
+def test_live_proof_secret_pattern_has_exact_generated_suffix_width() -> None:
+    template = synth_template_for_repositories(
+        E2E_CANARY_REPO, target_environment="nonprod"
+    )
+    _, policy = find_managed_policy_with_logical_id(template, LIVE_PROOF_POLICY_NAME)
+    statement = next(
+        statement
+        for statement in policy["Properties"]["PolicyDocument"]["Statement"]
+        if statement["Sid"] == "WorkOsProviderSecretRead"
+    )
+    resource = str(statement["Resource"])
+    resource_pattern = "campps/identity-access/nonprod/workos/api-key-??????"
+
+    assert resource_pattern in resource
+    assert resource.count("?") == 6
+    assert "/api-key-*" not in resource
+    assert "/api-key-copy-" not in resource
+    assert "/api-key-old-" not in resource
+    assert fnmatchcase(
+        "campps/identity-access/nonprod/workos/api-key-Ab12xy",
+        resource_pattern,
+    )
+    for forbidden_name in (
+        "campps/identity-access/nonprod/workos/api-key-copy-Ab12xy",
+        "campps/identity-access/nonprod/workos/api-key-old-Ab12xy",
+        "campps/identity-access/nonprod/workos/api-key-Ab12x",
+        "campps/identity-access/nonprod/workos/api-key-Ab12xyz",
+        "campps/identity-access/staging/workos/api-key-Ab12xy",
+    ):
+        assert not fnmatchcase(forbidden_name, resource_pattern)
+
+
+def test_live_proof_policy_is_not_attached_to_existing_deploy_role() -> None:
+    template = synth_template_for_repositories(
+        E2E_CANARY_REPO, target_environment="nonprod"
+    )
+    live_policy_logical_id, _ = find_managed_policy_with_logical_id(
+        template, LIVE_PROOF_POLICY_NAME
+    )
+    deploy_role = find_deploy_role(template, E2E_CANARY_REPO.role_name("nonprod"))
+
+    assert {"Ref": live_policy_logical_id} not in deploy_role["Properties"][
+        "ManagedPolicyArns"
+    ]
+    assert find_managed_policy(template, IDENTITY_SCOPE_READBACK_POLICY_NAME)
+
+
+def test_live_proof_resources_are_nonprod_e2e_canary_only() -> None:
+    higher_environments: tuple[DeployEnvironment, ...] = ("staging", "production")
+    for environment in higher_environments:
+        higher_template = synth_template_for_repositories(
+            E2E_CANARY_ALL_ENVIRONMENTS_REPO,
+            target_environment=environment,
+        )
+        assert_no_live_proof_resources(higher_template)
+
+    for unrelated_service in (
+        TENANT_SETUP_REPO,
+        ServiceRepository(
+            name="identity-access",
+            repository="infiquetra/campps-identity-access",
+        ),
+    ):
+        unrelated_template = synth_template_for_repositories(
+            unrelated_service,
+            target_environment="nonprod",
+        )
+        assert_no_live_proof_resources(unrelated_template)
+
+
+def test_live_proof_synth_is_stable() -> None:
+    first = synth_template_for_repositories(
+        E2E_CANARY_REPO, target_environment="nonprod"
+    ).to_json()
+    second = synth_template_for_repositories(
+        E2E_CANARY_REPO, target_environment="nonprod"
+    ).to_json()
+
+    assert first == second


### PR DESCRIPTION
## Summary

- add a separate one-hour GitHub OIDC role for the protected campps-e2e-canary nonprod live proof
- attach one managed policy with only canonical WorkOS API-key GetSecretValue and exact Identity Access table GetItem
- prove no deploy-role, unrelated-service, staging, production, KMS, write, query, scan, or broad-resource widening

Refs [campps-e2e-canary#4](https://github.com/infiquetra/campps-e2e-canary/issues/4).

## Context

- [E2E canary executor](https://github.com/infiquetra/campps-context-library/blob/main/platform-specs/05-technical-specifications/testing/e2e-canary-executor.md)
- [E2E scenario registry](https://github.com/infiquetra/campps-context-library/blob/main/platform-specs/05-technical-specifications/testing/e2e-scenario-registry/README.md)
- [Outcome-close E2E accounting](https://github.com/infiquetra/campps-context-library/blob/main/platform-specs/11-implementation-guides/outcome-close-e2e-accounting.md)

## Verification

- focused deploy-role module: 60 passed
- full suite: 76 passed
- Ruff check/format, strict mypy, Bandit, and git diff check: passed
- explicit app_campps_bootstrap.py synth: passed for nonprod, staging, and production
- synthesized templates: one nonprod live-proof role/policy/output; none in staging or production
- credentialed CamppsNonProdDeployRolesStack diff: two additive IAM resources and one output; no modify/delete
- Verified Workflows: PASS, 13 selected roles, 4 command-backed validators, no blockers or warnings
- review consensus: 8/8 PROCEED, per-perspective score 9.5, no P0-P3 findings

## Deployment boundary

Merge does not deploy the workload bootstrap app. After merge, the operator-approved path will rerun the target-stack diff from main, deploy only CamppsNonProdDeployRolesStack, and read back CloudFormation, role trust, attached policy, positive and negative IAM simulations, unchanged deploy-role authority, and the canary Environment role ARN.

## AI generation

95%
