### PR TITLE
fix(iam): include exact base-stack ARN in CloudFormation deploy scope

### DIFF
--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -444,6 +444,14 @@ class CamppsDeployRolesStack(Stack):
                     "cloudformation:UpdateStack",
                 ],
                 resources=[
+                    # Services name their base stack exactly `{prefix}` (no
+                    # component suffix); the `-*` pattern alone excludes it.
+                    self.format_arn(
+                        service="cloudformation",
+                        resource="stack",
+                        resource_name=f"{prefix}/*",
+                        arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                    ),
                     self.format_arn(
                         service="cloudformation",
                         resource="stack",
@@ -1065,6 +1073,15 @@ class CamppsDeployRolesStack(Stack):
                             "cloudformation:UpdateStack",
                         ],
                         resources=[
+                            # Services name their base stack exactly
+                            # `{prefix}` (no component suffix); the `-*`
+                            # pattern alone excludes it.
+                            self.format_arn(
+                                service="cloudformation",
+                                resource="stack",
+                                resource_name=f"{prefix}/*",
+                                arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                            ),
                             self.format_arn(
                                 service="cloudformation",
                                 resource="stack",


### PR DESCRIPTION
## Problem

Service repos name their base CloudFormation stack exactly `campps-<service>-<env>` (no component suffix), but both `CloudFormationDeployments` statements in `campps_deploy_roles_stack.py` scope stack ARNs to `stack/campps-<service>-<env>-*/*` — the `-*` requires a suffix, so the exact-named base stack never matches.

CDK deploys still succeed because they execute through the assumed `cdk-hnb659fds-*` bootstrap roles. The gap only bites when the GHA deploy role calls CloudFormation directly: `campps-coppa-consent`'s **Export deployed endpoint** step (`aws cloudformation describe-stacks` on `stack/campps-coppa-consent-nonprod`) failed `AccessDenied` in [run 29560099118](https://github.com/infiquetra/campps-coppa-consent/actions/runs/29560099118), blocking the L2 wave-1 synthetic-health verification chain. `campps-registration` carries the identical latent mismatch (`stack/campps-registration-nonprod` vs `campps-registration-nonprod-*/*`) and would hit it at its combine slice.

## Fix

Add the exact `stack/<prefix>/*` ARN alongside the existing suffixed pattern, in both the shared `_cloudformation_baseline_statements` and the serverless-api deploy policy. Least privilege preserved — the addition is each service's own base stack, nothing wider.

## Verification

- `uv run pytest tests/unit/test_campps_deploy_roles_stack.py` — 60 passed.
- `ruff check` clean.
- Post-merge: deploy-infrastructure rolls the policy; then re-run campps-coppa-consent `deploy-nonprod.yml` and confirm the export step passes.

Part of the L2 consent-and-registration outcome (context-library #39) unattended run.

https://claude.ai/code/session_01YYtFSQywiy6K6h392WT5k8