### PR TITLE
fix(iam): serverless deploy roles can read exact-named tables + platform key metadata

### DIFF
--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -1404,13 +1404,40 @@ class CamppsDeployRolesStack(Stack):
                             "dynamodb:UpdateTimeToLive",
                         ],
                         resources=[
+                            # Services name their base table exactly
+                            # `{prefix}` (no component suffix); the `-*`
+                            # pattern alone excludes it.
+                            self.format_arn(
+                                service="dynamodb",
+                                resource="table",
+                                resource_name=prefix,
+                                arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                            ),
                             self.format_arn(
                                 service="dynamodb",
                                 resource="table",
                                 resource_name=f"{prefix}-*",
                                 arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                            ),
+                        ],
+                    ),
+                    iam.PolicyStatement(
+                        sid="PlatformKmsDescribe",
+                        actions=["kms:DescribeKey"],
+                        resources=[
+                            self.format_arn(
+                                service="kms",
+                                resource="key",
+                                resource_name="*",
+                                arn_format=ArnFormat.SLASH_RESOURCE_NAME,
                             )
                         ],
+                        conditions={
+                            "StringEquals": {
+                                "aws:ResourceTag/Service": "platform",
+                                "aws:ResourceTag/Environment": target_environment,
+                            }
+                        },
                     ),
                     iam.PolicyStatement(
                         sid="EventBridgeRules",


### PR DESCRIPTION
## Problem

Second instance of the exact-name-vs-suffixed-wildcard class fixed for CloudFormation in #145, now on the data side. `campps-coppa-consent`'s deployed-stack assertion tests (`tests/integration/test_deployed_stack_assertions.py`, run as the GHA deploy role in deploy-nonprod) need:

- `dynamodb:DescribeTable` + `dynamodb:DescribeTimeToLive` on `table/campps-coppa-consent-nonprod` — **implicitDeny**: the `DynamoDbTables` statement scopes `table/{prefix}-*` only, and every live campps table is named exactly `{prefix}` (verified: all four existing service tables).
- `kms:DescribeKey` on the platform PII key (resolved from SSM, used to prove the table's KMS binding) — **implicitDeny**: no KMS grant existed on the serverless deploy policy.

All three denials confirmed live via `iam simulate-principal-policy`. This blocked the L2 wave-1b coppa-consent combine-slice live assertions (capability campps-coppa-consent#2).

## Fix

- Add the exact `table/{prefix}` ARN alongside the suffixed pattern in `DynamoDbTables`.
- New `PlatformKmsDescribe` statement: `kms:DescribeKey` on `key/*` conditioned on `aws:ResourceTag/Service=platform` + `Environment=<env>` — the same tag-conditioned idiom the boundary already uses; the PII key carries exactly those tags (verified).

## Verification

- `ruff` clean, `mypy` clean, `pytest tests/unit/test_campps_deploy_roles_stack.py` 60 passed.
- Post-merge: deploy `CamppsNonProdDeployRolesStack` via `app_campps_bootstrap.py` (the foundation workflow does not apply workload role changes — LEARNINGS 2026-06-17/2026-07-17), then re-simulate all three action/resource pairs and re-run campps-coppa-consent deploy-nonprod.

Part of the L2 consent-and-registration outcome (context-library #39) unattended run.

https://claude.ai/code/session_01YYtFSQywiy6K6h392WT5k8