### PR TITLE
feat(campps-roles): source-scoped events:PutEvents for the e2e-canary payments emitter

### DIFF
--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -1837,6 +1837,30 @@ class CamppsDeployRolesStack(Stack):
                         )
                     ],
                 ),
+                # Payments-emitter harness (campps-context-library#39): the
+                # run_live-guarded canary lane emits the three payments contract
+                # events (PaymentSucceeded / PaymentFailed / RefundIssued) onto the
+                # shared platform bus so registration's payments-event consumer
+                # (C2.7b) and the [E2E] combine slice stop being producer-blocked.
+                # Scoped to Source=campps.payments only -- the canary cannot spoof
+                # any other producer's events. Nonprod bus only (staging/prod are
+                # separate accounts and untouched). See the approved seed-payload
+                # doc, section 1 (IAM delta).
+                iam.PolicyStatement(
+                    sid="PaymentsEmitterPutEvents",
+                    actions=["events:PutEvents"],
+                    resources=[
+                        self.format_arn(
+                            service="events",
+                            resource="event-bus",
+                            resource_name="campps-platform-nonprod",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
+                    conditions={
+                        "StringEquals": {"events:source": "campps.payments"},
+                    },
+                ),
             ],
         )
         role.add_managed_policy(policy)

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -1624,6 +1624,7 @@ def test_e2e_canary_nonprod_has_dedicated_two_read_live_proof_role() -> None:
     assert set(statements_by_sid) == {
         "WorkOsProviderSecretRead",
         "IdentityScopeReadback",
+        "PaymentsEmitterPutEvents",
     }
     assert set(
         normalize_actions(statements_by_sid["WorkOsProviderSecretRead"]["Action"])
@@ -1640,6 +1641,16 @@ def test_e2e_canary_nonprod_has_dedicated_two_read_live_proof_role() -> None:
     assert (
         "dynamodb:us-east-1:477152411873:table/campps-identity-access-nonprod"
     ) in scope_resource
+
+    emitter_statement = statements_by_sid["PaymentsEmitterPutEvents"]
+    assert set(normalize_actions(emitter_statement["Action"])) == {"events:PutEvents"}
+    emitter_resource = str(emitter_statement["Resource"])
+    assert (
+        "events:us-east-1:477152411873:event-bus/campps-platform-nonprod"
+    ) in emitter_resource
+    assert emitter_statement["Condition"] == {
+        "StringEquals": {"events:source": "campps.payments"}
+    }
 
     role = find_deploy_role(template, LIVE_PROOF_ROLE_NAME)
     assert role["Properties"]["MaxSessionDuration"] == 3600
@@ -1677,7 +1688,11 @@ def test_live_proof_policy_has_no_widened_actions_or_resources() -> None:
         for resource in normalize_resources(statement["Resource"])
     }
 
-    assert actions == {"secretsmanager:GetSecretValue", "dynamodb:GetItem"}
+    assert actions == {
+        "secretsmanager:GetSecretValue",
+        "dynamodb:GetItem",
+        "events:PutEvents",
+    }
     assert "*" not in actions
     assert "*" not in resources
     assert not any(action.startswith("kms:") for action in actions)
@@ -1685,6 +1700,17 @@ def test_live_proof_policy_has_no_widened_actions_or_resources() -> None:
         action in {"dynamodb:Query", "dynamodb:Scan", "dynamodb:PutItem"}
         for action in actions
     )
+    # The one write action (events:PutEvents) must be source-scoped, never a bare
+    # bus grant, so the canary cannot spoof another producer's events.
+    put_events_statements = [
+        statement
+        for statement in statements
+        if "events:PutEvents" in normalize_actions(statement["Action"])
+    ]
+    assert len(put_events_statements) == 1
+    assert put_events_statements[0]["Condition"] == {
+        "StringEquals": {"events:source": "campps.payments"}
+    }
     assert not any(
         "staging" in resource or "production" in resource for resource in resources
     )


### PR DESCRIPTION
## What

Adds one statement (`PaymentsEmitterPutEvents`) to the existing managed policy
`campps-e2e-canary-nonprod-gha-live-proof-policy` in
`_create_e2e_canary_live_proof_role` — nothing else. Same role, same OIDC trust,
same guard clause (`e2e-canary` + `nonprod` only).

The statement grants `events:PutEvents` on the nonprod platform event bus,
conditioned `StringEquals events:source = "campps.payments"`.

## Why

Unblocks the payments-emitter harness approved in
[payments-emitter-seed-payloads.md](https://github.com/infiquetra/campps-context-library/blob/main/docs/outcomes/l2-consent-registration/payments-emitter-seed-payloads.md)
§1 (status: approved). The `run_live`-guarded canary lane emits the three payments
contract events (`PaymentSucceeded` / `PaymentFailed` / `RefundIssued`) onto the
shared bus so registration's payments-event consumer (C2.7b, #26) and the [E2E]
combine slice (#30) stop being producer-blocked. No stub Lambda: this is one
bus-write path on the existing canary trust boundary.

## Exact synthesized statement JSON

From `cdk synth --app "python3 app_campps_bootstrap.py"` →
`CamppsNonProdDeployRolesStack.template.json`:

```json
{
  "Action": "events:PutEvents",
  "Condition": {
    "StringEquals": {
      "events:source": "campps.payments"
    }
  },
  "Effect": "Allow",
  "Resource": "arn:aws:events:us-east-1:477152411873:event-bus/campps-platform-nonprod",
  "Sid": "PaymentsEmitterPutEvents"
}
```

The condition **renders** in the synthesized policy — no fallback to a bare
bus-ARN grant was needed (the approved doc pre-authorized that fallback only if
the condition key could not be expressed for the action).

## Bus ARN verification (verify, never guess)

- CAMPPS services reference the bus via SSM parameter `/campps/platform/<env>/event-bus/arn`
  (see `campps-registration` `infra/app.py` `platform_param_names`, consumed in
  `infra/stacks/registration_stack.py`).
- Live value read from SSM (`aws ssm get-parameter --profile campps-nonprod`):
  `arn:aws:events:us-east-1:477152411873:event-bus/campps-platform-nonprod`
- Synthesized value (via `format_arn(service="events", resource="event-bus", resource_name="campps-platform-nonprod", SLASH_RESOURCE_NAME)`, the same precedent as the neighboring `ScopeSeamProducerEmit` grant):
  `arn:aws:events:us-east-1:477152411873:event-bus/campps-platform-nonprod`
- **They match exactly.** The nonprod stack is pinned to account `477152411873`.

## Least-privilege rationale

- Single action `events:PutEvents`, single resource (the one nonprod bus).
- Source-scoped: the `events:source = "campps.payments"` condition means the
  canary can only emit as the payments producer — it cannot spoof
  `campps.tenant-setup`, `campps.coppa-consent`, or any other producer.
- Nonprod account only. The `e2e-canary` + `nonprod` guard on
  `_create_e2e_canary_live_proof_role` is unchanged; verified the policy is
  **absent** from the synthesized staging and production templates.
- No write action other than this source-scoped emit; secret-read and
  DynamoDB `GetItem` statements are untouched.

## Verification performed

- `ruff check .`, `ruff format --check .`, `mypy .`, `bandit -r` — all pass (also via pre-commit).
- `pytest tests/unit/test_campps_deploy_roles_stack.py` — 60 pass, including updated
  live-proof assertions (new sid, action, resource, and the rendered Condition) and
  the least-privilege guard test (the one write action must carry the source condition).
- `cdk synth` of the bootstrap app + `cfn-lint` on the emitted templates — pass
  (only pre-existing unrelated W3037 CloudFront warnings).

## Notes / gaps

- CI's `cdk synth --all` + `cfn-lint` gates run the **default** app (`app.py` per
  `cdk.json`), which does not include the campps deploy-roles bootstrap stacks, and
  there is no pytest job in CI. So CI's green covers lint/type/security on the
  changed `.py` files; the synth-condition-render proof and the unit-test assertions
  above were run **locally** against `app_campps_bootstrap.py`.
- Pre-deploy: the grant is synth-proven but not yet live in account `477152411873`.
  Deploy is out of scope for this PR (happens via the repo's own deploy path on/after
  merge to main), so end-to-end emission is not yet exercised.

Part of infiquetra/campps-context-library#39.
