### PR TITLE
feat(campps-roles): grant registration-table GetItem to e2e-canary live-proof role

### DIFF
--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -1777,7 +1777,7 @@ class CamppsDeployRolesStack(Stack):
         service_repository: ServiceRepository,
         target_environment: DeployEnvironment,
     ) -> iam.Role | None:
-        """Create the two-read nonprod role used by the protected live proof."""
+        """Create the least-privilege nonprod role used by the protected live proof."""
         if service_repository.name != "e2e-canary" or target_environment != "nonprod":
             return None
 
@@ -1808,7 +1808,8 @@ class CamppsDeployRolesStack(Stack):
             "E2eCanaryLiveProofPolicy",
             managed_policy_name="campps-e2e-canary-nonprod-gha-live-proof-policy",
             description=(
-                "Two-read policy for the protected campps-e2e-canary nonprod live proof"
+                "Least-privilege policy for the protected campps-e2e-canary "
+                "nonprod live proof"
             ),
             statements=[
                 iam.PolicyStatement(
@@ -1860,6 +1861,24 @@ class CamppsDeployRolesStack(Stack):
                     conditions={
                         "StringEquals": {"events:source": "campps.payments"},
                     },
+                ),
+                # Waitlist extended-legs live proof (registration#40): the canary
+                # verifies SessionCapacity counter handoff (confirmed -> pending
+                # promotion, no open-capacity blip), strict FIFO offer order, and
+                # the 48-hour offer window by reading exact-keyed items from the
+                # registration table. GetItem only -- no Query/Scan, no writes;
+                # offer aging stays an operator-run update outside this role.
+                iam.PolicyStatement(
+                    sid="RegistrationCounterReadback",
+                    actions=["dynamodb:GetItem"],
+                    resources=[
+                        self.format_arn(
+                            service="dynamodb",
+                            resource="table",
+                            resource_name="campps-registration-nonprod",
+                            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+                        )
+                    ],
                 ),
             ],
         )

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -1625,6 +1625,7 @@ def test_e2e_canary_nonprod_has_dedicated_two_read_live_proof_role() -> None:
         "WorkOsProviderSecretRead",
         "IdentityScopeReadback",
         "PaymentsEmitterPutEvents",
+        "RegistrationCounterReadback",
     }
     assert set(
         normalize_actions(statements_by_sid["WorkOsProviderSecretRead"]["Action"])
@@ -1641,6 +1642,13 @@ def test_e2e_canary_nonprod_has_dedicated_two_read_live_proof_role() -> None:
     assert (
         "dynamodb:us-east-1:477152411873:table/campps-identity-access-nonprod"
     ) in scope_resource
+
+    counter_statement = statements_by_sid["RegistrationCounterReadback"]
+    assert set(normalize_actions(counter_statement["Action"])) == {"dynamodb:GetItem"}
+    counter_resource = str(counter_statement["Resource"])
+    assert (
+        "dynamodb:us-east-1:477152411873:table/campps-registration-nonprod"
+    ) in counter_resource
 
     emitter_statement = statements_by_sid["PaymentsEmitterPutEvents"]
     assert set(normalize_actions(emitter_statement["Action"])) == {"events:PutEvents"}


### PR DESCRIPTION
Part of infiquetra/campps-registration#40 (via campps-context-library#39 / L2 consent-registration).

## What

Adds one statement (`RegistrationCounterReadback`) to `campps-e2e-canary-nonprod-gha-live-proof-policy`: `dynamodb:GetItem` on `arn:aws:dynamodb:us-east-1:477152411873:table/campps-registration-nonprod`.

## Why

The registration#40 waitlist extended legs (campps-e2e-canary#28) prove the SessionCapacity counter handoff (confirmed → pending_promotion with no open-capacity blip), strict two-entry FIFO offer order, and the ~48h offer window by reading exact-keyed items (`REG#`/`CAP#`) from the registration table during the protected live run. The live-proof role currently has no registration-table access, so those legs AccessDeny and record blocked.

## Least-privilege notes

- `GetItem` only — no Query/Scan (asserted by the existing widened-actions test), no writes.
- Single exact-named nonprod table; staging/prod untouched (separate accounts, asserted).
- Offer-window aging remains an operator-run `update-item` outside this role.
- Mirrors the existing `IdentityScopeReadback` statement shape.

## Deploy

Not CI-deployed: requires an operator `cdk deploy` of `CamppsNonProdDeployRolesStack` via `app_campps_bootstrap.py` (same recipe as #148).

https://claude.ai/code/session_01YYtFSQywiy6K6h392WT5k8