### PR TITLE
fix(campps-roles): freeze live-proof policy description — replacement collides with pinned name

### DIFF
--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -1807,9 +1807,13 @@ class CamppsDeployRolesStack(Stack):
             self,
             "E2eCanaryLiveProofPolicy",
             managed_policy_name="campps-e2e-canary-nonprod-gha-live-proof-policy",
+            # Deployed description is frozen: AWS::IAM::ManagedPolicy replaces
+            # the resource on a Description change, and the pinned
+            # managed_policy_name makes create-before-delete collide (409
+            # AlreadyExists -> UPDATE_ROLLBACK_COMPLETE). Statement changes
+            # update in place; the description cannot without a rename.
             description=(
-                "Least-privilege policy for the protected campps-e2e-canary "
-                "nonprod live proof"
+                "Two-read policy for the protected campps-e2e-canary nonprod live proof"
             ),
             statements=[
                 iam.PolicyStatement(


### PR DESCRIPTION
Part of infiquetra/campps-registration#40.

The operator deploy of #149 failed (`UPDATE_ROLLBACK_COMPLETE`): the description change on the live-proof managed policy triggers resource replacement, and the replacement's create-before-delete collides with the pinned `managed_policy_name` (IAM 409 AlreadyExists). This reverts the `description` parameter to the exact deployed string and documents the constraint inline. The `RegistrationCounterReadback` statement addition is unchanged and updates in place.