### PR TITLE
feat(campps-roles): grant alias-pinned kms:Decrypt so the live-proof registration read works

### DIFF
--- a/infiquetra_aws_infra/campps_deploy_roles_stack.py
+++ b/infiquetra_aws_infra/campps_deploy_roles_stack.py
@@ -1884,6 +1884,27 @@ class CamppsDeployRolesStack(Stack):
                         )
                     ],
                 ),
+                # The registration table is SSE-encrypted with the shared
+                # customer-managed platform PII key, so the GetItem above dies
+                # with kms:Decrypt AccessDenied without this. Pinned by alias
+                # (survives key rotation/recreation, no hardcoded key UUID) and
+                # by ViaService so the grant works only through DynamoDB reads,
+                # never as a direct kms:Decrypt call.
+                iam.PolicyStatement(
+                    sid="RegistrationTableKeyDecrypt",
+                    actions=["kms:Decrypt"],
+                    resources=["*"],
+                    conditions={
+                        "StringEquals": {
+                            "kms:ViaService": "dynamodb.us-east-1.amazonaws.com",
+                        },
+                        # kms:ResourceAliases is multivalued -- a plain
+                        # StringEquals never matches; ForAnyValue is required.
+                        "ForAnyValue:StringEquals": {
+                            "kms:ResourceAliases": "alias/campps-platform-nonprod-pii",
+                        },
+                    },
+                ),
             ],
         )
         role.add_managed_policy(policy)

--- a/tests/unit/test_campps_deploy_roles_stack.py
+++ b/tests/unit/test_campps_deploy_roles_stack.py
@@ -1626,6 +1626,7 @@ def test_e2e_canary_nonprod_has_dedicated_two_read_live_proof_role() -> None:
         "IdentityScopeReadback",
         "PaymentsEmitterPutEvents",
         "RegistrationCounterReadback",
+        "RegistrationTableKeyDecrypt",
     }
     assert set(
         normalize_actions(statements_by_sid["WorkOsProviderSecretRead"]["Action"])
@@ -1649,6 +1650,15 @@ def test_e2e_canary_nonprod_has_dedicated_two_read_live_proof_role() -> None:
     assert (
         "dynamodb:us-east-1:477152411873:table/campps-registration-nonprod"
     ) in counter_resource
+
+    key_statement = statements_by_sid["RegistrationTableKeyDecrypt"]
+    assert set(normalize_actions(key_statement["Action"])) == {"kms:Decrypt"}
+    assert key_statement["Condition"] == {
+        "StringEquals": {"kms:ViaService": "dynamodb.us-east-1.amazonaws.com"},
+        "ForAnyValue:StringEquals": {
+            "kms:ResourceAliases": "alias/campps-platform-nonprod-pii"
+        },
+    }
 
     emitter_statement = statements_by_sid["PaymentsEmitterPutEvents"]
     assert set(normalize_actions(emitter_statement["Action"])) == {"events:PutEvents"}
@@ -1700,14 +1710,34 @@ def test_live_proof_policy_has_no_widened_actions_or_resources() -> None:
         "secretsmanager:GetSecretValue",
         "dynamodb:GetItem",
         "events:PutEvents",
+        "kms:Decrypt",
     }
     assert "*" not in actions
-    assert "*" not in resources
-    assert not any(action.startswith("kms:") for action in actions)
     assert not any(
         action in {"dynamodb:Query", "dynamodb:Scan", "dynamodb:PutItem"}
         for action in actions
     )
+    # kms:Decrypt is the sole kms action, and the only statement allowed a "*"
+    # resource: KMS grants cannot name an alias in Resource, so the statement
+    # is pinned by the alias condition instead and must never work outside a
+    # DynamoDB read (ViaService) or against any key but the platform PII alias.
+    assert {action for action in actions if action.startswith("kms:")} == {
+        "kms:Decrypt"
+    }
+    star_statements = [
+        statement
+        for statement in statements
+        if "*" in normalize_resources(statement["Resource"])
+    ]
+    assert [statement["Sid"] for statement in star_statements] == [
+        "RegistrationTableKeyDecrypt"
+    ]
+    assert star_statements[0]["Condition"] == {
+        "StringEquals": {"kms:ViaService": "dynamodb.us-east-1.amazonaws.com"},
+        "ForAnyValue:StringEquals": {
+            "kms:ResourceAliases": "alias/campps-platform-nonprod-pii"
+        },
+    }
     # The one write action (events:PutEvents) must be source-scoped, never a bare
     # bus grant, so the canary cannot spoof another producer's events.
     put_events_statements = [


### PR DESCRIPTION
Part of infiquetra/campps-registration#40.

Live run 29787913748 (first run with the extended legs active) blocked all five table-read criteria: the registration table is SSE-encrypted with the customer-managed `alias/campps-platform-nonprod-pii` key, so the #149 `GetItem` grant fails with `kms:Decrypt` AccessDenied (the identity table read never hit this — it uses the AWS-owned key). This grants `kms:Decrypt` pinned two ways: `kms:ViaService = dynamodb.us-east-1.amazonaws.com` (only through DynamoDB reads, never a direct KMS call) and `ForAnyValue:StringEquals kms:ResourceAliases = alias/campps-platform-nonprod-pii` (only that key; alias condition instead of a hardcoded key UUID, and ForAnyValue because ResourceAliases is multivalued). The guard test now asserts kms:Decrypt is the sole KMS action and the only statement allowed a `*` resource — and only with both conditions present.